### PR TITLE
Video prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,5 @@ dmypy.json
 # DS_Store
 **/.DS_Store
 
-# specific stuff
-pose_est_nets/datasets/MNIST/
-pose_est_nets/datasets/lightning_logs/
+# specific stuff like csv predictions on test_vid.mp4
+toy_datasets/toymouseRunningData/unlabeled_videos/*.csv

--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ As you would do for any other repository, first --
 
 Create the environment:
 
-```conda create --name <YOUR_ENVIRONMENT_NAME>```
+```console 
+foo@bar:~$ conda create --name <YOUR_ENVIRONMENT_NAME>
+```
 
 Activate the environment:
 
-```conda activate <YOUR_ENVIRONMENT_NAME>```
+```console
+foo@bar:~$ conda activate <YOUR_ENVIRONMENT_NAME>
+```
 
 Move into the folder where you want to place the repository folder:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The script relies on **Hydra** to manage arguments in hierarchical config files.
 
 ## Logs and saved models
 
-The outputs of the training script, namely the model checkpoints and `Tensorboard` logs, will be saved at the `outputs/YYYY-MM-DD/tb_logs` directory.
+The outputs of the training script, namely the model checkpoints and `Tensorboard` logs, will be saved at the `lightning-pose/outputs/YYYY-MM-DD/tb_logs` directory.
 
 To view the logged losses with tensorboard, in the command line, run:
 
@@ -75,13 +75,47 @@ To view the logged losses with tensorboard, in the command line, run:
 
 where you use the date in which you ran the model.
 
-## Prediction and visualization
+## Visualize train/test/val predictions:
 
-Visualize the models' predictions on the `train/test/val` datasets using the `FiftyOne` app: 
+You can visualize the predictions of one or multiple trained models on the `train/test/val` images using the `FiftyOne` app.
 
-```python scripts/predict_compare.py```
+You will need to specify:
+1. `eval.hydra_paths`: path to trained models to use for prediction. 
 
+Generally, using `Hydra` we can either edit the config `.yaml` files or override them from command line. 
 
+### Option 1: Edit the config
 
+Edit `scripts/configs/eval/eval_params.yaml` like so:
+```
+hydra_paths: [
+"YYYY-MM-DD/HH-MM-SS/", "YYYY-MM-DD/HH-MM-SS/",
+]
+```
+where you specify the relative paths for `hydra` folders within the `lightning-pose/outputs` folder. Then from command line, run:
+```
+python scripts/predict_compare.py
+```
 
+### Option 2: Override from command line
+Specify `hydra_paths` in the command line, overriding the `.yaml`:
+```
+python scripts/predict_compare.py eval.hydra_paths=["YYYY-MM-DD/HH-MM-SS/"]
+``` 
+where again, `hydra_paths` should be a list of strings with folder names within `lightning-pose/outputs`.
 
+## Predict keypoints on new videos
+With a trained model and a path to a new videos, you can generate predictions for each frame and save it as a `.csv` or `.h5` file. You need to specify two paths:
+1. `eval.hydra_paths`: path to models to use for prediction: 
+2. `eval.path_to_test_videos`: path to a *folder* with new videos
+3. `path_to_save_predictions`: optional path specifying where to save predictions. If `null`, the predictions will be saved in `eval.path_to_test_videos`.
+
+as in above, you could directly edit `scripts/configs/eval/eval_params.yaml` and run
+```
+python scripts/predict_new_vids.py 
+```
+or override these arguments in the command line.
+
+```
+python scripts/predict_new_vids.py eval.hydra_paths=["YYYY-MM-DD/HH-MM-SS/"] eval.path_to_save_predictions="/path/to/your/file.csv" eval.path_to_test_videos="path/to/test/vids"
+```

--- a/README.md
+++ b/README.md
@@ -17,39 +17,39 @@ Provide more GPUs and we will use them.
 ## Installation
 
 First create a Conda environment in which this package and its dependencies will be installed. 
-As you would do for any other repository, first --
+As you would do for any other repository --
 
-Create the environment:
+Create a conda environment:
 
 ```console 
 foo@bar:~$ conda create --name <YOUR_ENVIRONMENT_NAME>
 ```
 
-Activate the environment:
+and activate it:
 
 ```console
 foo@bar:~$ conda activate <YOUR_ENVIRONMENT_NAME>
 ```
 
-Move into the folder where you want to place the repository folder:
+Move into the folder where you want to place the repository folder, and then download it from GitHub:
 
-```cd <SOME_FOLDER>```
+```console
+foo@bar:~$ cd <SOME_FOLDER>
+foo@bar:~$ git clone https://github.com/danbider/lightning-pose.git
+```
 
-From within that folder, download a local version of the GitHub folder:
+Then move into the newly-created repository folder, and install dependencies:
 
-```git clone https://github.com/danbider/lightning-pose.git```
-
-Then move into the new package folder:
-
-```cd lightning-pose```
-
-Install our package and its dependencies:
-
-`pip install -r requirements.txt`
+```console
+foo@bar:~$ cd lightning-pose
+foo@bar:~$ pip install -r requirements.txt
+```
 
 You should be ready to go! You may verify that all the unit tests are passing on your machine by running
 
-```pytest```
+```console
+foo@bar:~$ pytest
+```
 
 ## Datasets
 * `BaseDataset`: images + keypoint coordinates.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ where again, `hydra_paths` should be a list of strings with folder names within 
 ## Predict keypoints on new videos
 With a trained model and a path to a new videos, you can generate predictions for each frame and save it as a `.csv` or `.h5` file. You need to specify two paths:
 1. `eval.hydra_paths`: path to models to use for prediction: 
-2. `eval.path_to_test_videos`: path to a *folder* with new videos
+2. `eval.path_to_test_videos`: path to a *folder* with new videos (not a single video)
 3. `path_to_save_predictions`: optional path specifying where to save predictions. If `null`, the predictions will be saved in `eval.path_to_test_videos`.
 
 as in above, you could directly edit `scripts/configs/eval/eval_params.yaml` and run

--- a/pose_est_nets/datasets/dali.py
+++ b/pose_est_nets/datasets/dali.py
@@ -40,7 +40,7 @@ def count_frames(video_full_path: str) -> int:
 # cannot typecheck due to way pipeline_def decorator consumes additional args
 @pipeline_def
 def video_pipe(
-    filenames: Union[list[str], str],
+    filenames: Union[List[str], str],
     resize_dims: Optional[List[int]] = None,
     random_shuffle: bool = False,
     seed: int = 123456,

--- a/pose_est_nets/datasets/datasets.py
+++ b/pose_est_nets/datasets/datasets.py
@@ -66,19 +66,21 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             if not os.path.exists(csv_file):
                 # step 3: assume dlc directory structure
                 import glob
+
                 glob_path = os.path.join(
-                        root_directory,
-                        "training-datasets",
-                        "iteration-0",
-                        "*",  # wildcard handles proj-specific dlc naming conventions
-                        csv_path,
-                    )
+                    root_directory,
+                    "training-datasets",
+                    "iteration-0",
+                    "*",  # wildcard handles proj-specific dlc naming conventions
+                    csv_path,
+                )
                 options = glob.glob(glob_path)
                 if not options or not os.path.exists(options[0]):
                     raise FileNotFoundError("Could not find csv file!")
                 csv_file = options[0]
 
         csv_data = pd.read_csv(csv_file, header=header_rows)
+        self.keypoint_names = csv_data.columns.levels[0][1:]
         self.image_names = list(csv_data.iloc[:, 0])
         self.keypoints = torch.tensor(
             csv_data.iloc[:, 1:].to_numpy(), dtype=torch.float32

--- a/pose_est_nets/losses/losses.py
+++ b/pose_est_nets/losses/losses.py
@@ -13,8 +13,8 @@ patch_typeguard()  # use before @typechecked
 
 @typechecked
 def MaskedRegressionMSELoss(
-    keypoints: TensorType["batch", "2 x num_keypoints"],
-    preds: TensorType["batch", "2 x num_keypoints"],
+    keypoints: TensorType["batch", "two_x_num_keypoints"],
+    preds: TensorType["batch", "two_x_num_keypoints"],
 ) -> TensorType[(), float]:
     """Compute MSE loss between ground truth and predicted coordinates.
 
@@ -35,8 +35,8 @@ def MaskedRegressionMSELoss(
 
 @typechecked
 def MaskedRMSELoss(
-    keypoints: TensorType["batch", "2 x num_keypoints"],
-    preds: TensorType["batch", "2 x num_keypoints"],
+    keypoints: TensorType["batch", "two_x_num_keypoints"],
+    preds: TensorType["batch", "two_x_num_keypoints"],
 ) -> TensorType[(), float]:
     """Compute RMSE loss between ground truth and predicted coordinates.
 
@@ -90,7 +90,7 @@ def MaskedMSEHeatmapLoss(
 @typechecked
 # what are we doing about NANS?
 def MultiviewPCALoss(
-    reshaped_maxima_preds: TensorType["batch", "2 x num_keypoints", float],
+    reshaped_maxima_preds: TensorType["batch", "two_x_num_keypoints", float],
     discarded_eigenvectors: TensorType["views_times_two", "num_discarded_evecs", float],
     epsilon: TensorType[float],
     **kwargs  # make loss robust to unneeded inputs
@@ -133,7 +133,7 @@ def MultiviewPCALoss(
 
 @typechecked
 def TemporalLoss(
-    preds: TensorType["batch", "2 x num_keypoints"],
+    preds: TensorType["batch", "two_x_num_keypoints"],
     epsilon: TensorType[float] = 5,
     **kwargs  # make loss robust to unneeded inputs
 ) -> TensorType[(), float]:

--- a/pose_est_nets/models/regression_tracker.py
+++ b/pose_est_nets/models/regression_tracker.py
@@ -10,7 +10,7 @@ from typing_extensions import Literal
 from pose_est_nets.losses.losses import (
     convert_dict_entries_to_tensors,
     get_losses_dict,
-    MaskedMSEHeatmapLoss,
+    MaskedRegressionMSELoss,
     MaskedRMSELoss,
 )
 from pose_est_nets.models.base_resnet import BaseFeatureExtractor
@@ -77,7 +77,7 @@ class RegressionTracker(BaseFeatureExtractor):
     def forward(
         self,
         images: TensorType["batch", "channels":3, "image_height", "image_width", float],
-    ) -> TensorType["batch", "2 x num_keypoints"]:
+    ) -> TensorType["batch", "two_x_num_keypoints"]:
         """Forward pass through the network.
 
         Args:

--- a/pose_est_nets/utils/fiftyone_plotting_utils.py
+++ b/pose_est_nets/utils/fiftyone_plotting_utils.py
@@ -17,8 +17,8 @@ def tensor_to_keypoint_list(keypoint_tensor, height, width):  # TODO: move to ut
         img_kpts_list.append(
             tuple(
                 (
-                    float(keypoint_tensor[i][0] / height),
-                    float(keypoint_tensor[i][1] / width),
+                    float(keypoint_tensor[i][0] / width),  # height
+                    float(keypoint_tensor[i][1] / height),  # width
                 )
             )
         )

--- a/pose_est_nets/utils/heatmap_tracker_utils.py
+++ b/pose_est_nets/utils/heatmap_tracker_utils.py
@@ -243,10 +243,10 @@ class SubPixelMaxima:  # Add tensor typing
         kernel_size = (kernel_size // largest_factor(kernel_size)) + 1
         return torch.tensor(kernel_size, device=self.device)
 
-    def run( #TODO: maybe we should see if we can add batch functionality
+    def run(  # TODO: maybe we should see if we can add batch functionality
         self,
         heatmaps_1: torch.Tensor,
-        heatmaps_2: torch.Tensor=None,  # Enables the function to be run with only one set of keypoints
+        heatmaps_2: torch.Tensor = None,  # Enables the function to be run with only one set of keypoints
     ):
         keypoints_1 = find_subpixel_maxima(
             heatmaps_1,  # .detach(),  TODO: is there a reason to detach?
@@ -261,7 +261,7 @@ class SubPixelMaxima:  # Add tensor typing
             return self.use_threshold(keypoints_1)
 
         keypoints_2 = find_subpixel_maxima(
-            heatmaps_2,  #.detach(),
+            heatmaps_2,  # .detach(),
             self.kernel_size,
             self.output_sigma,
             self.upsample_factor,
@@ -270,20 +270,20 @@ class SubPixelMaxima:  # Add tensor typing
         )
         return self.use_threshold(keypoints_1), self.use_threshold(keypoints_2)
 
-    def use_threshold(self, keypoints: torch.tensor):  # TODO: figure out what to do with batched masking, different elements of the batch could be masked into different sizes, which would cause a shape mismatch, could just turn masked elements into nans
+    def use_threshold(
+        self, keypoints: torch.tensor
+    ):  # TODO: figure out what to do with batched masking, different elements of the batch could be masked into different sizes, which would cause a shape mismatch, could just turn masked elements into nans
         if not self.threshold:
             num_threshold = torch.tensor(-1, device=self.device)
         else:
             num_threshold = torch.tensor(self.threshold, device=keypoints.device)
-        #print(keypoints.shape)
+        # print(keypoints.shape)
         batch_dim, num_bodyparts, _ = keypoints.shape
         mask = torch.gt(keypoints[:, :, 2], num_threshold)
-        #print(mask.shape)
+        # print(mask.shape)
         mask = mask.unsqueeze(-1)
-        keypoints = torch.masked_select(keypoints, mask).reshape(
-            batch_dim, -1, 3
-        )
-        #print(keypoints.shape)
+        keypoints = torch.masked_select(keypoints, mask).reshape(batch_dim, -1, 3)
+        # print(keypoints.shape)
         confidence = keypoints[:, :, 2]
         keypoints = keypoints[:, :, :2]
         return keypoints.reshape(keypoints.shape[0], -1), confidence

--- a/pose_est_nets/utils/io.py
+++ b/pose_est_nets/utils/io.py
@@ -45,3 +45,48 @@ def get_latest_version(lightning_logs_path: str) -> str:
     latest_version = subfolders[ints.index(max(ints))]
     print("version used: %s" % latest_version)
     return latest_version
+
+
+def get_absolute_hydra_path_from_hydra_str(hydra_path: str) -> str:
+    import os
+
+    cwd_split = os.getcwd().split(os.path.sep)
+    desired_path_list = cwd_split[:-2]
+    absolute_path = os.path.join(os.path.sep, *desired_path_list, hydra_path)
+    assert os.path.isdir(absolute_path)
+    return absolute_path
+
+
+def ckpt_path_from_base_path(
+    base_path: str,
+    model_name: str,
+    logging_dir_name: str = "tb_logs/",
+    version: int = 0,
+) -> str:
+    """Given a path to a hydra output with trained model, extract the .ckpt to later load weights.
+
+    Args:
+        base_path (str): path to a folder with logs and checkpoint. for example, function will search base_path/logging_dir_name/model_name...
+        model_name (str): the name you gave your model before training it; appears as model_name in lightning-pose/scripts/config/model_params.yaml
+        logging_dir_name (str, optional): name of the folder in logs, controlled in train_hydra.py Defaults to "tb_logs/".
+
+    Returns:
+        str: path to model checkpoint
+    """
+    # TODO: consider finding the most recent hydra path containing logging_dir_name
+    import glob
+    import os
+
+    model_search_path = os.path.join(
+        base_path,
+        logging_dir_name,  # TODO: may change when we switch from Tensorboard
+        model_name,  # get the name string of the model (determined pre-training)
+        "version_%i"
+        % version,  # always version_0 because ptl starts a version_0 folder in a new hydra outputs folder
+        "checkpoints",
+        "*.ckpt",
+    )
+
+    # TODO: we're taking the last ckpt. make sure that with multiple checkpoints, this is what we want
+    model_ckpt_path = glob.glob(model_search_path)[-1]
+    return model_ckpt_path

--- a/pose_est_nets/utils/plotting_utils.py
+++ b/pose_est_nets/utils/plotting_utils.py
@@ -18,6 +18,20 @@ from tqdm import tqdm
 from omegaconf import DictConfig, OmegaConf
 
 
+def get_videos_in_dir(video_dir: str) -> List[str]:
+    # gather videos to process
+    # TODO: check if you're give a path to a single video?
+    assert os.path.isdir(video_dir)
+    all_files = [video_dir + "/" + f for f in os.listdir(video_dir)]
+    video_files = []
+    for f in all_files:
+        if f.endswith(".mp4"):
+            video_files.append(f)
+    if len(video_files) == 0:
+        raise IOError("Did not find any video files (.mp4) in %s" % video_dir)
+    return video_files
+
+
 def get_model_class(map_type: str, semi_supervised: bool):
     """[summary]
 
@@ -221,7 +235,10 @@ def predict_videos(
         HeatmapTracker,
         SemiSupervisedHeatmapTracker,
     )
-    from pose_est_nets.utils.io import set_or_open_folder, get_latest_version
+    from pose_est_nets.utils.io import (
+        set_or_open_folder,
+        get_latest_version,
+    )
 
     # check input
     if save_file is not None:

--- a/pose_est_nets/utils/plotting_utils.py
+++ b/pose_est_nets/utils/plotting_utils.py
@@ -15,8 +15,9 @@ import os
 from typing import Callable, Optional, Tuple, List
 from typeguard import typechecked
 
+
 def get_model_class(map_type: str, semi_supervised: bool):
-    if not(semi_supervised):
+    if not (semi_supervised):
         if map_type == "regression":
             return RegressionTracker
         elif map_type == "heatmap":
@@ -26,6 +27,7 @@ def get_model_class(map_type: str, semi_supervised: bool):
             return SemiSupervisedRegressionTracker
         elif map_type == "heatmap":
             return SemiSupervisedHeatmapTracker
+
 
 def saveNumericalPredictions(model, datamod, threshold):
     i = 0
@@ -39,7 +41,9 @@ def saveNumericalPredictions(model, datamod, threshold):
     full_dl = datamod.full_dataloader()
     test_dl = datamod.test_dataloader()
     final_gt_keypoints = np.empty(shape=(len(test_dl), model.num_keypoints, 2))
-    final_imgs = np.empty(shape=(len(test_dl), 406, 396, 1))
+    final_imgs = np.empty(
+        shape=(len(test_dl), 406, 396, 1)
+    )  # TODO: specific to Rick data
     final_preds = np.empty(shape=(len(test_dl), model.num_keypoints, 2))
 
     # dpk_final_preds = np.empty(shape = (len(test_dl), model.num_keypoints, 2))
@@ -126,8 +130,14 @@ def plotPredictions(model, datamod, save_heatmaps, threshold, mode):
 
 
 def predict_videos(
-        video_path, model_file, config_file, save_file=None, sequence_length=16, device="gpu",
-        video_pipe_kwargs={}):
+    video_path,
+    model_file,
+    config_file,
+    save_file=None,
+    sequence_length=16,
+    device="gpu",
+    video_pipe_kwargs={},
+):
     """Loop over a list of videos and process with tracker using DALI for fast inference.
 
     Args:
@@ -138,7 +148,7 @@ def predict_videos(
             - config_file.data.image_orig_dims
             - config_file.data.image_resize_dims
             - config_file.model.losses_to_use
-            - config_file.model.data_type
+            - config_file.model.model_type
             - config_file.model.semi_supervised
         save_file (str): full filename of tracked points; currently supports hdf5 and csv; if
             NoneType, the output will be saved in the video path
@@ -162,16 +172,25 @@ def predict_videos(
 
     from pose_est_nets.datasets.dali import video_pipe, LightningWrapper, count_frames
     from pose_est_nets.datasets.datasets import BaseTrackingDataset, HeatmapDataset
-    from pose_est_nets.models.regression_tracker import RegressionTracker, \
-        SemiSupervisedRegressionTracker
-    from pose_est_nets.models.heatmap_tracker import HeatmapTracker, SemiSupervisedHeatmapTracker
+    from pose_est_nets.models.regression_tracker import (
+        RegressionTracker,
+        SemiSupervisedRegressionTracker,
+    )
+    from pose_est_nets.models.heatmap_tracker import (
+        HeatmapTracker,
+        SemiSupervisedHeatmapTracker,
+    )
     from pose_est_nets.utils.io import set_or_open_folder, get_latest_version
 
     # check input
     if save_file is not None:
-        if not (save_file.endswith(".csv") or save_file.endswith(".hdf5")
-                or save_file.endswith(".hdf") or save_file.endswith(".h5")
-                or save_file.endswith(".h")):
+        if not (
+            save_file.endswith(".csv")
+            or save_file.endswith(".hdf5")
+            or save_file.endswith(".hdf")
+            or save_file.endswith(".h5")
+            or save_file.endswith(".h")
+        ):
             raise NotImplementedError("Currently only .csv and .h5 files are supported")
 
     if device == "gpu" or device == "cuda":
@@ -194,33 +213,41 @@ def predict_videos(
         raise IOError("Did not find any video files (.mp4) in %s" % video_path)
 
     # load configuration file
-    with open(config_file, 'r') as f:
+    with open(config_file, "r") as f:
         cfg = OmegaConf.load(f)
 
     # load model weights
     if not cfg.model.semi_supervised:
-        if cfg.model.data_type == "regression":
+        if cfg.model.model_type == "regression":
             model = RegressionTracker.load_from_checkpoint(model_file)
-        elif cfg.model.data_type == "heatmap":
+        elif cfg.model.model_type == "heatmap":
             model = HeatmapTracker.load_from_checkpoint(model_file)
         else:
             raise NotImplementedError
     else:
         loss_param_dict = OmegaConf.to_object(cfg.losses)
         losses_to_use = OmegaConf.to_object(cfg.model.losses_to_use)
-        if cfg.model.data_type == "regression":
+        if cfg.model.model_type == "regression":
             model = SemiSupervisedRegressionTracker.load_from_checkpoint(
-                model_file, semi_super_losses_to_use=losses_to_use, loss_params=loss_param_dict)
-        elif cfg.model.data_type == "heatmap":
+                model_file,
+                semi_super_losses_to_use=losses_to_use,
+                loss_params=loss_param_dict,
+            )
+        elif cfg.model.model_type == "heatmap":
             model = SemiSupervisedHeatmapTracker.load_from_checkpoint(
-                model_file, semi_super_losses_to_use=losses_to_use, loss_params=loss_param_dict)
+                model_file,
+                semi_super_losses_to_use=losses_to_use,
+                loss_params=loss_param_dict,
+            )
         else:
             raise NotImplementedError
     model.to(device_pt)
     model.eval()
 
     # set some defaults
-    batch_size = 1  # don't change this, change sequence length (exposed to user) instead
+    batch_size = (
+        1  # don't change this, change sequence length (exposed to user) instead
+    )
     video_pipe_kwargs_defaults = {"num_threads": 2, "device_id": 0}
     for key, val in video_pipe_kwargs_defaults.items():
         if key not in video_pipe_kwargs.keys():
@@ -233,14 +260,28 @@ def predict_videos(
 
         # build video loader/pipeline
         pipe = video_pipe(
-            resize_dims=(cfg.data.image_resize_dims.height, cfg.data.image_resize_dims.width),
-            batch_size=batch_size, sequence_length=sequence_length, filenames=[video_file],
-            random_shuffle=False, device=device_dali, name="reader", pad_sequences=True,
-            **video_pipe_kwargs)
+            resize_dims=(
+                cfg.data.image_resize_dims.height,
+                cfg.data.image_resize_dims.width,
+            ),
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            filenames=[video_file],
+            random_shuffle=False,
+            device=device_dali,
+            name="reader",
+            pad_sequences=True,
+            **video_pipe_kwargs
+        )
 
         predict_loader = LightningWrapper(
-            pipe, output_map=["x"], last_batch_policy=LastBatchPolicy.FILL,
-            last_batch_padded=False, auto_reset=False, reader_name="reader")
+            pipe,
+            output_map=["x"],
+            last_batch_policy=LastBatchPolicy.FILL,
+            last_batch_padded=False,
+            auto_reset=False,
+            reader_name="reader",
+        )
 
         # iterate through video
         n_frames_ = count_frames(video_file)  # total frames in video
@@ -251,8 +292,10 @@ def predict_videos(
         with torch.no_grad():
             for n, batch in enumerate(predict_loader):
                 outputs = model.forward(batch)
-                if cfg.model.data_type == "heatmap":
-                    pred_keypoints, confidence = model.run_subpixelmaxima(outputs).detach().cpu().numpy()
+                if cfg.model.model_type == "heatmap":
+                    pred_keypoints, confidence = (
+                        model.run_subpixelmaxima(outputs).detach().cpu().numpy()
+                    )
                 else:
                     pred_keypoints = outputs.detach().cpu().numpy()
                 n_frames_curr = pred_keypoints.shape[0]
@@ -262,23 +305,33 @@ def predict_videos(
                     keypoints_np[n_frames:] = pred_keypoints[:final_batch_size]
                     n_frames_curr = final_batch_size
                 else:
-                    keypoints_np[n_frames:n_frames + n_frames_curr] = pred_keypoints
+                    keypoints_np[n_frames : n_frames + n_frames_curr] = pred_keypoints
                 n_frames += n_frames_curr
             t_end = time.time()
             if n == -1:
-                print("WARNING: issue processing %s" % video_file)  # TODO: what can go wrong here?
+                print(
+                    "WARNING: issue processing %s" % video_file
+                )  # TODO: what can go wrong here?
                 continue
             else:
-                print("inference speed: %1.2f fr/sec" % ((n * sequence_length) / (t_end - t_beg)))
+                print(
+                    "inference speed: %1.2f fr/sec"
+                    % ((n * sequence_length) / (t_end - t_beg))
+                )
 
         # save csv file of predictions in DeepLabCut format
         if save_file is None:
             # create filename based on video name and model type
             video_file_name = os.path.basename(video_file).replace(".mp4", "")
-            loss_str = "_".join([""] + cfg.model.losses_to_use) \
-                if len(cfg.model.losses_to_use) > 0 else ""
+            loss_str = (
+                "_".join([""] + cfg.model.losses_to_use)
+                if len(cfg.model.losses_to_use) > 0
+                else ""
+            )
             save_file = os.path.join(
-                video_path, "%s_%s%s.csv" % (video_file_name, cfg.model.data_type, loss_str))
+                video_path,
+                "%s_%s%s.csv" % (video_file_name, cfg.model.model_type, loss_str),
+            )
 
         num_joints = int(model.num_targets // 2)
         predictions = np.zeros((keypoints_np.shape[0], num_joints * 3))
@@ -293,9 +346,9 @@ def predict_videos(
         predictions[:, 1::3] = keypoints_np[:, 1::2] / y_resize * y_og
 
         xyl_labels = ["x", "y", "likelihood"]
-        joint_labels = ['bp_%i' % n for n in range(model.num_targets // 2)]
+        joint_labels = ["bp_%i" % n for n in range(model.num_targets // 2)]
         pdindex = pd.MultiIndex.from_product(
-            [["%s_tracker" % cfg.model.data_type], joint_labels, xyl_labels],
+            [["%s_tracker" % cfg.model.model_type], joint_labels, xyl_labels],
             names=["scorer", "bodyparts", "coords"],
         )
         df = pd.DataFrame(predictions, columns=pdindex)

--- a/pose_est_nets/utils/plotting_utils.py
+++ b/pose_est_nets/utils/plotting_utils.py
@@ -282,7 +282,6 @@ def predict_videos(
     model = load_model_from_checkpoint(cfg=cfg, ckpt_file=ckpt_file, eval=True)
 
     model.to(device_pt)
-    model.eval()
 
     # set some defaults
     batch_size = (
@@ -326,8 +325,8 @@ def predict_videos(
         # iterate through video
         n_frames_ = count_frames(video_file)  # total frames in video
         n_frames = 0  # total frames processed
-        keypoints_np = np.zeros((n_frames_, model.num_targets))
-        confidence_np = np.zeros((n_frames_, model.num_targets // 2))
+        keypoints_np = np.zeros((n_frames_, model.num_keypoints * 2))
+        confidence_np = np.zeros((n_frames_, model.num_keypoints))
 
         t_beg = time.time()
         n = -1

--- a/scripts/configs/data/data_params.yaml
+++ b/scripts/configs/data/data_params.yaml
@@ -4,15 +4,15 @@ image_orig_dims:
   width: 396
 
 # resize dimensions to streamline model creation
-image_resize_dims: 
-  height: 384 
-  width: 384
+image_resize_dims:
+  height: 256
+  width: 256
 
-# absolute path to data directory
-data_dir: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/"
+# ABSOLUTE path to data directory. the below is just a toy example for running Getting Started scripts
+data_dir: "toy_datasets/toymouseRunningData"
 
-# absolute path to unlabeled videos' directory (TODO: Matt, can have multiple vids)
-video_dir: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
+# ABSOLUTE path to unlabeled videos' directory. the below is just a toy example for running Getting Started scripts (TODO: Matt, can have multiple vids)
+video_dir: "unlabeled_videos"
 
 # location of labels; for example script, this should be relative to `data_dir`
 csv_file: "CollectedData_.csv"
@@ -25,5 +25,4 @@ downsample_factor: 2
 
 # total number of predictions; 2 * num_keypoints
 num_targets: 34
-
 # add parameters related to the ground truth heatmaps, sigma, confidence_scale, etc

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -1,7 +1,8 @@
 # path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
-hydra_paths: ["2021-10-29/13-53-17/", "2021-10-29/18-01-11/"]
+hydra_paths:
+  ["2021-10-29/13-53-17/", "2021-10-29/18-01-11/", "2021-10-31/00-11-36"]
 
-model_names: [] # if you want to manually provide a different model name to be displayed in FiftyOne
+model_names: ["toy_model_2", "toy_model_3"] # if you want to manually provide a different model name to be displayed in FiftyOne
 
 fifty_one_dataset_name: "rick_data_test"
 

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -11,7 +11,7 @@ fifty_one_dataset_name: "rick_data_test"
 path_to_test_videos: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos" #"/datastores/mouseRunningData/1/unlabeled_videos"
 
 # path to save the .csv file with preds:
-path_to_save_predictions: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/bla.csv" # either csv or h5
+path_to_save_predictions: null # "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/bla.csv" # either csv or h5
 
 # params for loading images from the video using nvidia-dali
 dali_parameters:

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -1,14 +1,14 @@
-#path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
+# path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
 hydra_paths: [
   "2021-10-20/20-28-45/"
 ]
 
-model_names: ["simple_unsupervised_heatmap"] #["baseheatmap1", "semisupervisedheatmap2", "semisupervisedregression3"] #Names could be more descriptive
+model_names: [] # if you want to manually provide a different model name to be displayed in FiftyOne
 
 fifty_one_dataset_name: "rick_data_test"
 
-# path to new unlabeled videos for prediction
-path_to_test_videos:  "/datastores/mouseRunningData/1/unlabeled_videos"
+# path to new unlabeled videos for prediction 
+path_to_test_videos: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos" #"/datastores/mouseRunningData/1/unlabeled_videos"
 
 # params for loading images from the video using nvidia-dali
 dali_parameters:

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -1,13 +1,11 @@
 # path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
-hydra_paths: [
-  "2021-10-20/20-28-45/"
-]
+hydra_paths: ["2021-10-29/13-53-17/", "2021-10-29/18-01-11/"]
 
 model_names: [] # if you want to manually provide a different model name to be displayed in FiftyOne
 
 fifty_one_dataset_name: "rick_data_test"
 
-# path to new unlabeled videos for prediction 
+# path to new unlabeled videos for prediction
 path_to_test_videos: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos" #"/datastores/mouseRunningData/1/unlabeled_videos"
 
 # path to save the .csv file with preds:
@@ -15,6 +13,5 @@ path_to_save_predictions: null # "/home/jovyan/lightning-pose/toy_datasets/toymo
 
 # params for loading images from the video using nvidia-dali
 dali_parameters:
-
   # how many frames to grab at once from the video
   sequence_length: 64

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -10,6 +10,9 @@ fifty_one_dataset_name: "rick_data_test"
 # path to new unlabeled videos for prediction 
 path_to_test_videos: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos" #"/datastores/mouseRunningData/1/unlabeled_videos"
 
+# path to save the .csv file with preds:
+path_to_save_predictions: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/bla.csv" # either csv or h5
+
 # params for loading images from the video using nvidia-dali
 dali_parameters:
 

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -1,16 +1,19 @@
 # path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
 hydra_paths:
-  ["2021-10-29/13-53-17/", "2021-10-29/18-01-11/", "2021-10-31/00-11-36"]
+  ["2021-11-01/00-13-04/", "2021-11-01/00-21-04/", "2021-11-01/00-46-34"]
 
-model_names: ["toy_model_2", "toy_model_3"] # if you want to manually provide a different model name to be displayed in FiftyOne
+model_names: ["toy_model_2", "toy_model_3", "quick_model"] # if you want to manually provide a different model name to be displayed in FiftyOne
 
 fifty_one_dataset_name: "rick_data_test"
 
-# path to new unlabeled videos for prediction
-path_to_test_videos: "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos" #"/datastores/mouseRunningData/1/unlabeled_videos"
+# absolute path to new unlabeled videos for prediction (it's not absolute just for the example)
+path_to_test_videos: "toy_datasets/toymouseRunningData/unlabeled_videos"
+
+# absolute path to the .csv with predictions for each vid in path_to_test_videos
+path_to_csv_predictions: "toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv"
 
 # path to save the .csv file with preds:
-path_to_save_predictions: null # "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/bla.csv" # either csv or h5
+path_to_save_predictions: null # either .csv or .h5
 
 # params for loading images from the video using nvidia-dali
 dali_parameters:

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -1,16 +1,19 @@
 # path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
-hydra_paths:
-  ["2021-11-01/00-13-04/", "2021-11-01/00-21-04/", "2021-11-01/00-46-34"]
+hydra_paths: ["2021-11-01/00-21-04/", "2021-11-01/00-46-34"]
 
-model_names: ["toy_model_2", "toy_model_3", "quick_model"] # if you want to manually provide a different model name to be displayed in FiftyOne
+model_display_names: ["toy_model_3", "quick_model"] # if you want to manually provide a different model name to be displayed in FiftyOne
 
 fifty_one_dataset_name: "rick_data_test"
 
-# absolute path to new unlabeled videos for prediction (it's not absolute just for the example)
-path_to_test_videos: "toy_datasets/toymouseRunningData/unlabeled_videos"
+# list with absolute paths to new unlabeled videos folders for prediction (it's not absolute just for the example)
+path_to_test_videos: ["toy_datasets/toymouseRunningData/unlabeled_videos"]
 
-# absolute path to the .csv with predictions for each vid in path_to_test_videos
-path_to_csv_predictions: "toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv"
+# list with absolute paths to the .csv with predictions for each vid in path_to_test_videos
+path_to_csv_predictions:
+  [
+    "toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv",
+    "toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap_temporal.csv",
+  ]
 
 # path to save the .csv file with preds:
 path_to_save_predictions: null # either .csv or .h5

--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -1,10 +1,17 @@
 #path to the hydra config file in the output folder, we can use it reconstruct information about loss directory
 hydra_paths: [
-  "2021-10-18/19-19-24/", 
-  "2021-10-18/19-22-08"
-  # "2021-10-15/04-24-52/",
-  # "2021-10-15/04-28-08/",
-  # "2021-10-15/04-30-19/"
+  "2021-10-20/20-28-45/"
 ]
-model_names: ["simple_heatmap", "simple_unsupervised_heatmap"] #["baseheatmap1", "semisupervisedheatmap2", "semisupervisedregression3"] #Names could be more descriptive
-fifty_one_dataset_name: "mouse_data2"
+
+model_names: ["simple_unsupervised_heatmap"] #["baseheatmap1", "semisupervisedheatmap2", "semisupervisedregression3"] #Names could be more descriptive
+
+fifty_one_dataset_name: "rick_data_test"
+
+# path to new unlabeled videos for prediction
+path_to_test_videos:  "/datastores/mouseRunningData/1/unlabeled_videos"
+
+# params for loading images from the video using nvidia-dali
+dali_parameters:
+
+  # how many frames to grab at once from the video
+  sequence_length: 64

--- a/scripts/configs/losses/loss_params.yaml
+++ b/scripts/configs/losses/loss_params.yaml
@@ -1,6 +1,5 @@
 # loss = projection onto the discarded eigenvectors
 pca:
-
   # weight in front of PCA loss
   weight: 0.6
 
@@ -15,9 +14,8 @@ pca:
 
 # loss = norm of distance between successive timepoints
 temporal:
-
   # weight in front of temporal loss
   weight: 0.7
 
   # for epsilon insensitive rectification (in pixels; diffs below this are not penalized)
-  epsilon: null
+  epsilon: 10.

--- a/scripts/configs/model/model_params.yaml
+++ b/scripts/configs/model/model_params.yaml
@@ -5,10 +5,10 @@ losses_to_use: ["temporal"]
 resnet_version: 18
 
 # whether to include a sequence of unlabeled frames; must be accompanied by non-empty losses_to_use
-semi_supervised: True
+semi_supervised: False
 
 # prediction mode: "heatmap" | "regression"
 model_type: "heatmap"
 
 # directory name for model saving
-model_name: "my_second_toy_model"
+model_name: "my_base_toy_model"

--- a/scripts/configs/model/model_params.yaml
+++ b/scripts/configs/model/model_params.yaml
@@ -1,14 +1,14 @@
-# list of unsupervised losses: "pca" | "temporal"
-losses_to_use: ["pca"]
+# list of unsupervised losses: "pca" | "temporal", default: null
+losses_to_use: ["temporal"]
 
 # resnet version for backbone: 18 | 34 | 50 | 101 | 152
-resnet_version: 50
+resnet_version: 18
 
 # whether to include a sequence of unlabeled frames; must be accompanied by non-empty losses_to_use
-semi_supervised: False
+semi_supervised: True
 
 # prediction mode: "heatmap" | "regression"
 model_type: "heatmap"
 
 # directory name for model saving
-model_name: "my_test_model"
+model_name: "my_small_mouse_visualize_model"

--- a/scripts/configs/model/model_params.yaml
+++ b/scripts/configs/model/model_params.yaml
@@ -11,4 +11,4 @@ semi_supervised: True
 model_type: "heatmap"
 
 # directory name for model saving
-model_name: "my_small_mouse_visualize_model"
+model_name: "my_second_toy_model"

--- a/scripts/predict_compare.py
+++ b/scripts/predict_compare.py
@@ -1,45 +1,22 @@
-"""want:
+"""process:
 1. give paths to checkpoints (with models)
 2. initialize those models
 3. setup a datamodule with (train/test/val images; one or more datamodules needed?)
 4. get predictions and log them to fiftyone
 5. launch fiftyone
 6. separately connect with ssh tunnel and inspect"""
+
 import os
 import time
 import pytorch_lightning as pl
 import hydra
 from omegaconf import DictConfig, OmegaConf
 import imgaug.augmenters as iaa
-# from pose_est_nets.models.heatmap_tracker import (
-#     HeatmapTracker,
-#     SemiSupervisedHeatmapTracker,
-# )
-# from pose_est_nets.models.regression_tracker import (
-#     RegressionTracker,
-#     SemiSupervisedRegressionTracker,
-# )
 from pose_est_nets.datasets.datamodules import BaseDataModule, UnlabeledDataModule
 from pose_est_nets.datasets.datasets import BaseTrackingDataset, HeatmapDataset
 from pose_est_nets.utils.fiftyone_plotting_utils import make_dataset_and_evaluate
 from pose_est_nets.utils.plotting_utils import get_model_class
 
-# path = "/home/jovyan/pose-estimation-nets/outputs/2021-09-30/00-08-34/tb_logs/my_test_model/version_0/checkpoints/epoch=1-step=105.ckpt"
-# Semi supervised heatmap tracker
-# path = "/home/ubuntu/pose-estimation-nets/outputs/2021-09-30/05-41-05/tb_logs/my_test_model/version_0/checkpoints/epoch=299-step=15899.ckpt"
-# # regular heatmap tracker
-# path2 = "/home/ubuntu/pose-estimation-nets/outputs/2021-09-30/04-27-31/tb_logs/my_test_model/version_0/checkpoints/epoch=249-step=13249.ckpt"
-# # Semi supervised regression tracker
-# path3 = "/home/ubuntu/pose-estimation-nets/outputs/2021-09-30/22-19-37/tb_logs/my_test_model/version_0/checkpoints/epoch=169-step=9009.ckpt"
-# # regular regression tracker
-# path4 = "/home/ubuntu/pose-estimation-nets/outputs/2021-09-30/23-50-18/tb_logs/my_test_model/version_0/checkpoints/epoch=146-step=7790.ckpt"
-
-# MODEL_CLASS_FROM_TYPE = {
-#     "RegressionTracker": RegressionTracker,
-#     "SemiSupervisedRegressionTracker": SemiSupervisedRegressionTracker,
-#     "HeatmapTracker": HeatmapTracker,
-#     "SemiSupervisedHeatmapTracker": SemiSupervisedHeatmapTracker
-# }
 
 @hydra.main(config_path="configs", config_name="config")
 def predict(cfg: DictConfig):
@@ -60,12 +37,12 @@ def predict(cfg: DictConfig):
     # Assume we are using heatmap dataset for evaluation even if no models are heatmap models
     dataset = HeatmapDataset(
         root_directory=cfg.data.data_dir,
-        csv_path=cfg.data.csv_path,
+        csv_path=cfg.data.csv_file,
         header_rows=OmegaConf.to_object(cfg.data.header_rows),
         imgaug_transform=imgaug_transform,
         downsample_factor=cfg.data.downsample_factor,
     )
-    #We don't need the unsupervised functionality for testing purposes on labeled frames, but keep for now because it sets up loss_param_dict
+    # We don't need the unsupervised functionality for testing purposes on labeled frames, but keep for now because it sets up loss_param_dict
     datamod = UnlabeledDataModule(
         dataset=dataset,
         video_paths_list=cfg.data.video_dir,  # just a single path for now
@@ -76,57 +53,38 @@ def predict(cfg: DictConfig):
         test_batch_size=cfg.training.test_batch_size,
         num_workers=cfg.training.num_workers,
     )
-    # datamod = BaseDataModule(
-    #     dataset=dataset,
-    #     train_batch_size=cfg.training.train_batch_size,
-    #     validation_batch_size=cfg.training.val_batch_size,
-    #     test_batch_size=cfg.training.test_batch_size,
-    #     num_workers=cfg.training.num_workers,
-    # )
-
-    # if "SemiSupervisedRegressionTracker" in cfg.eval.model_types or "SemiSupervisedHeatmapTracker" in cfg.eval.model_types:
-    # else:
-
 
     # for now this works without saving the pca params to dict
     bestmodels = {}
     for model_name, hydra_path in zip(cfg.eval.model_names, cfg.eval.hydra_paths):
         if hydra_path[-1] != "/":
             hydra_path += "/"
-        model_config = OmegaConf.load("../../" + hydra_path + '.hydra/config.yaml')
-        ModelClass = get_model_class(model_config.model.model_type, model_config.model.semi_supervised)
-        ckpt_path = "../../" + hydra_path + "tb_logs/" + model_config.model.model_name + "/version_0/checkpoints/"
+        model_config = OmegaConf.load("../../" + hydra_path + ".hydra/config.yaml")
+        ModelClass = get_model_class(
+            model_config.model.model_type, model_config.model.semi_supervised
+        )
+        ckpt_path = (
+            "../../"
+            + hydra_path
+            + "tb_logs/"
+            + model_config.model.model_name
+            + "/version_0/checkpoints/"
+        )
         model_path = ckpt_path + os.listdir(ckpt_path)[0]
         if model_config.model.semi_supervised:
             model = ModelClass.load_from_checkpoint(
-                model_path, semi_super_losses_to_use=OmegaConf.to_object(model_config.model.losses_to_use), loss_params=loss_param_dict #loss param dict is generic
+                model_path,
+                semi_super_losses_to_use=OmegaConf.to_object(
+                    model_config.model.losses_to_use
+                ),
+                loss_params=loss_param_dict,  # loss param dict is generic
             )
         else:
-            model = ModelClass.load_from_checkpoint(
-                model_path
-            )
+            model = ModelClass.load_from_checkpoint(model_path)
         bestmodels[model_name] = model
     print("loaded weights")
     make_dataset_and_evaluate(cfg, datamod, bestmodels)
 
-
-    # model = SemiSupervisedHeatmapTracker.load_from_checkpoint(
-    #     path, semi_super_losses_to_use=losses_to_use, loss_params=loss_param_dict
-    # )
-    # model2 = HeatmapTracker.load_from_checkpoint(path2)
-    # model3 = SemiSupervisedRegressionTracker.load_from_checkpoint(
-    #     path3, semi_super_losses_to_use=losses_to_use, loss_params=loss_param_dict
-    # )
-    # model4 = RegressionTracker.load_from_checkpoint(path4)
-
-    # model = model.load_from_checkpoint(path, strict=False)
-    
-    # bestmodels = {
-    #     "semi_supervised_heatmap_tracker": model,
-    #     "base_heatmap_tracker": model2,
-    #     "semi_supervised_regression_tracker": model3,
-    #     "base_regression_tracker": model4,
-    # }
 
 if __name__ == "__main__":
     predict()

--- a/scripts/predict_compare.py
+++ b/scripts/predict_compare.py
@@ -56,19 +56,16 @@ def predict(cfg: DictConfig):
 
     # for now this works without saving the pca params to dict
     bestmodels = {}
-    for model_name, hydra_path in zip(cfg.eval.model_names, cfg.eval.hydra_paths):
+    for hydra_path in cfg.eval.hydra_paths:
         if hydra_path[-1] != "/":
             hydra_path += "/"
         model_config = OmegaConf.load("../../" + hydra_path + ".hydra/config.yaml")
+        model_name = model_config.model.model_name
         ModelClass = get_model_class(
             model_config.model.model_type, model_config.model.semi_supervised
         )
         ckpt_path = (
-            "../../"
-            + hydra_path
-            + "tb_logs/"
-            + model_config.model.model_name
-            + "/version_0/checkpoints/"
+            "../../" + hydra_path + "tb_logs/" + model_name + "/version_0/checkpoints/"
         )
         model_path = ckpt_path + os.listdir(ckpt_path)[0]
         if model_config.model.semi_supervised:
@@ -82,7 +79,6 @@ def predict(cfg: DictConfig):
         else:
             model = ModelClass.load_from_checkpoint(model_path)
         bestmodels[model_name] = model
-    print("loaded weights")
     make_dataset_and_evaluate(cfg, datamod, bestmodels)
 
 

--- a/scripts/predict_new_vids.py
+++ b/scripts/predict_new_vids.py
@@ -5,42 +5,38 @@ import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
 
-from pose_est_nets.utils.plotting_utils import predict_videos
+from pose_est_nets.utils.plotting_utils import (
+    predict_videos,
+)
+from pose_est_nets.utils.io import (
+    get_absolute_hydra_path_from_hydra_str,
+    ckpt_path_from_base_path,
+)
 
 
 @hydra.main(config_path="configs", config_name="config")
 def make_predictions(cfg: DictConfig):
+    """this script will work with a path to a trained model's hydra folder
+    from that folder it'll read the info about the model, get the checkpoint, and predict on a new vid"""
     """note, by decorating with hydra, the current working directory will be become the new folder os.path.join(os.getcwd(), "/outputs/YYYY-MM-DD/hour-info")"""
-
     # go to folders up to the "outputs" folder, and search for hydra_path from cfg
-    model_config_path = os.path.join(
-        "../..", cfg.eval.hydra_paths[0], ".hydra/config.yaml"
-    )
-    model_config_file = OmegaConf.load(model_config_path)
+    for hydra_relative_path in cfg.eval.hydra_paths:
+        # cfg.eval.hydra_paths defines a list of relative paths to hydra folders "YYYY-MM-DD/HH-MM-SS", and we extract an absolute path below
+        absolute_cfg_path = get_absolute_hydra_path_from_hydra_str(hydra_relative_path)
+        model_cfg = OmegaConf.load(
+            os.path.join(absolute_cfg_path, ".hydra/config.yaml")
+        )  # path for the cfg file saved from the current trained model
+        ckpt_file = ckpt_path_from_base_path(
+            base_path=absolute_cfg_path, model_name=model_cfg.model.model_name
+        )
 
-    model_search_path = os.path.join(
-        "../..",  # go two folders up to the outputs/ folder
-        cfg.eval.hydra_paths[
-            0
-        ],  # TODO: this is a list of paths, right now we're supporting one
-        "tb_logs",  # TODO: may change when we switch from Tensorboard
-        model_config_file.model.model_name,  # get the name string of the model (determined pre-training)
-        "version_0",  # always version_0 because ptl starts a version_0 folder in a new hydra outputs folder
-        "checkpoints",
-        "*.ckpt",
-    )
-
-    # TODO: we're taking the last ckpt. make sure that with multiple checkpoints, this is what we want
-    model_ckpt_path = glob.glob(model_search_path)[
-        -1
-    ]  # the output of glob.glob is a list with all files that match the search.
-    predict_videos(
-        video_path=cfg.eval.path_to_test_videos,
-        model_file=model_ckpt_path,
-        config_file=model_config_path,
-        save_file=cfg.eval.path_to_save_predictions,
-        sequence_length=cfg.eval.dali_parameters.sequence_length,
-    )
+        predict_videos(
+            video_path=cfg.eval.path_to_test_videos,
+            ckpt_file=ckpt_file,
+            cfg_file=model_cfg,
+            save_file=cfg.eval.path_to_save_predictions,
+            sequence_length=cfg.eval.dali_parameters.sequence_length,
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/predict_new_vids.py
+++ b/scripts/predict_new_vids.py
@@ -34,12 +34,11 @@ def make_predictions(cfg: DictConfig):
     model_ckpt_path = glob.glob(model_search_path)[
         -1
     ]  # the output of glob.glob is a list with all files that match the search.
-
     predict_videos(
-        cfg.eval.path_to_test_videos,
-        model_ckpt_path,
-        model_config_path,
-        None,
+        video_path=cfg.eval.path_to_test_videos,
+        model_file=model_ckpt_path,
+        config_file=model_config_path,
+        save_file=cfg.eval.path_to_save_predictions,
         sequence_length=cfg.eval.dali_parameters.sequence_length,
     )
 

--- a/scripts/predict_new_vids.py
+++ b/scripts/predict_new_vids.py
@@ -1,0 +1,48 @@
+import glob
+import os
+import numpy as np
+import hydra
+import torch
+from omegaconf import DictConfig, OmegaConf
+
+from pose_est_nets.utils.plotting_utils import predict_videos
+
+
+@hydra.main(config_path="configs", config_name="config")
+def make_predictions(cfg: DictConfig):
+    """note, by decorating with hydra, the current working directory will be become the new folder os.path.join(os.getcwd(), "/outputs/YYYY-MM-DD/hour-info")"""
+
+    # go to folders up to the "outputs" folder, and search for hydra_path from cfg
+    model_config_path = os.path.join(
+        "../..", cfg.eval.hydra_paths[0], ".hydra/config.yaml"
+    )
+    model_config_file = OmegaConf.load(model_config_path)
+
+    model_search_path = os.path.join(
+        "../..",  # go two folders up to the outputs/ folder
+        cfg.eval.hydra_paths[
+            0
+        ],  # TODO: this is a list of paths, right now we're supporting one
+        "tb_logs",  # TODO: may change when we switch from Tensorboard
+        model_config_file.model.model_name,  # get the name string of the model (determined pre-training)
+        "version_0",  # always version_0 because ptl starts a version_0 folder in a new hydra outputs folder
+        "checkpoints",
+        "*.ckpt",
+    )
+
+    # TODO: we're taking the last ckpt. make sure that with multiple checkpoints, this is what we want
+    model_ckpt_path = glob.glob(model_search_path)[
+        -1
+    ]  # the output of glob.glob is a list with all files that match the search.
+
+    predict_videos(
+        cfg.eval.path_to_test_videos,
+        model_ckpt_path,
+        model_config_path,
+        None,
+        sequence_length=cfg.eval.dali_parameters.sequence_length,
+    )
+
+
+if __name__ == "__main__":
+    make_predictions()

--- a/scripts/predict_new_vids.py
+++ b/scripts/predict_new_vids.py
@@ -11,6 +11,7 @@ from pose_est_nets.utils.plotting_utils import (
 from pose_est_nets.utils.io import (
     get_absolute_hydra_path_from_hydra_str,
     ckpt_path_from_base_path,
+    verify_absolute_path,
 )
 
 
@@ -30,8 +31,12 @@ def make_predictions(cfg: DictConfig):
             base_path=absolute_cfg_path, model_name=model_cfg.model.model_name
         )
 
+        absolute_path_to_test_videos = verify_absolute_path(
+            cfg.eval.path_to_test_videos
+        )
+
         predict_videos(
-            video_path=cfg.eval.path_to_test_videos,
+            video_path=absolute_path_to_test_videos,
             ckpt_file=ckpt_file,
             cfg_file=model_cfg,
             save_file=cfg.eval.path_to_save_predictions,

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -1,15 +1,16 @@
 import fiftyone as fo
 import pandas as pd
 import os
-import fiftyone.utils.video as fouv
+import fiftyone.utils.annotations as foua
 
-# TODO: make a dataset?
+
 dataset = fo.Dataset()
 
 video_path = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
 
-"""if video_path is not codec h.264:
+"""video_path, if mp4, should be codec h.264. if not:
 video_path_transformed = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/transformed_test_vid.mp4"
+import fiftyone.utils.video as fouv
 fouv.reencode_video(video_path, video_path_transformed, verbose=False)
 """
 
@@ -20,7 +21,7 @@ print(video_sample)
 
 
 csv_with_preds = pd.read_csv(
-    "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/bla.csv",
+    "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv",
     header=[1, 2],
 )
 
@@ -56,3 +57,4 @@ session.wait()
 #     break
 
 # now loop over the rows of the csv with prediction. add frame information as frame["predictions"]
+annotation_config = foua.AnnotationConfig()

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -7,6 +7,7 @@ import hydra
 from omegaconf import DictConfig, OmegaConf
 from pose_est_nets.utils.io import verify_absolute_path
 from pose_est_nets.utils.plotting_utils import get_videos_in_dir
+import warnings
 
 
 """For FifyOne visualization, videos, if mp4, should be codec h.264. If they're not, see below on how to convert them:
@@ -52,9 +53,13 @@ def render_labeled_videos(cfg: DictConfig):
         cfg.eval.path_to_test_videos[0]
     )  # TODO: just for now assuming there's one dir, but can have multiple dirs.
     video = get_videos_in_dir(video_dir)
-    assert (
-        len(video) == 1
-    )  # currently supporting a single video in a directory, TODO: extend and loop
+    if len(video) > 1:  # just until further support
+        warnings.warn(
+            "{} has more than one video. \nAnalyzing just {}".format(
+                video_dir, video[0]
+            )
+        )
+    # currently supporting a single video in a directory, TODO: extend and loop
     dataset = fo.Dataset(
         cfg.eval.fifty_one_dataset_name + "_videos"
     )  # TODO: in the future, dataset should include multiple video samples

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -1,0 +1,58 @@
+import fiftyone as fo
+import pandas as pd
+import os
+import fiftyone.utils.video as fouv
+
+# TODO: make a dataset?
+dataset = fo.Dataset()
+
+video_path = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
+
+"""if video_path is not codec h.264:
+video_path_transformed = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/transformed_test_vid.mp4"
+fouv.reencode_video(video_path, video_path_transformed, verbose=False)
+"""
+
+assert os.path.isfile(video_path)
+
+video_sample = fo.Sample(filepath=video_path)
+print(video_sample)
+
+
+csv_with_preds = pd.read_csv(
+    "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/bla.csv",
+    header=[1, 2],
+)
+
+# TODO: make as params
+height = 406
+width = 396
+
+bodypart_names = csv_with_preds.columns.levels[0][1:]
+# TODO: check how to populate and use the confidence field
+for frame_idx in range(csv_with_preds.shape[0]):  # loop over frames
+    pred_list = []
+    for bp in bodypart_names:  # loop over bp names
+        # that's quick but looses body part name labels
+        pred_list.append(
+            (
+                csv_with_preds[bp]["x"][frame_idx] / width,
+                csv_with_preds[bp]["y"][frame_idx] / height,
+            )
+        )
+    # note that their indexing starts from 1
+    video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(
+        keypoints=[fo.Keypoint(points=pred_list)]
+    )
+
+dataset.add_sample(video_sample)
+dataset.compute_metadata()
+# print(dataset)
+session = fo.launch_app(dataset, remote=True)
+session.wait()
+# inspect frames
+# for frame_number, frame in video_sample.frames.items():
+#     print(frame)
+#     break
+
+# now loop over the rows of the csv with prediction. add frame information as frame["predictions"]

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -3,9 +3,10 @@ import pandas as pd
 import os
 import fiftyone.utils.annotations as foua
 
-
+# TODO: name as param
 dataset = fo.Dataset()
 
+# TODO: as param
 video_path = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
 
 """video_path, if mp4, should be codec h.264. if not:
@@ -19,7 +20,7 @@ assert os.path.isfile(video_path)
 video_sample = fo.Sample(filepath=video_path)
 print(video_sample)
 
-
+# TODO: as param
 csv_with_preds = pd.read_csv(
     "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv",
     header=[1, 2],
@@ -50,6 +51,7 @@ dataset.add_sample(video_sample)
 dataset.compute_metadata()
 # print(dataset)
 
+# TODO: control more params from outside. also for app
 config = foua.DrawConfig(
     {"keypoints_size": 9}
 )  # note that 9 is approximately 40+ times smaller than the image
@@ -58,7 +60,7 @@ config = foua.DrawConfig(
 session = fo.launch_app(dataset, remote=True)
 session.wait()
 
-# Render the labels
+# TODO: by definition always save to disk.
 config = foua.DrawConfig({"keypoints_size": 9})
 outpath = "/home/jovyan/vid.mp4"
 print("Writing labeled images to '%s'" % outpath)

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -49,12 +49,25 @@ for frame_idx in range(csv_with_preds.shape[0]):  # loop over frames
 dataset.add_sample(video_sample)
 dataset.compute_metadata()
 # print(dataset)
+
+config = foua.DrawConfig(
+    {"keypoints_size": 9}
+)  # note that 9 is approximately 40+ times smaller than the image
+
+# launch an interactive session
 session = fo.launch_app(dataset, remote=True)
 session.wait()
+
+# Render the labels
+config = foua.DrawConfig({"keypoints_size": 9})
+outpath = "/home/jovyan/vid.mp4"
+print("Writing labeled images to '%s'" % outpath)
+foua.draw_labeled_video(video_sample, outpath, config=config)
+print("Writing complete")
+
+# save to disc
+
 # inspect frames
 # for frame_number, frame in video_sample.frames.items():
 #     print(frame)
 #     break
-
-# now loop over the rows of the csv with prediction. add frame information as frame["predictions"]
-annotation_config = foua.AnnotationConfig()

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -4,8 +4,6 @@ import os
 import fiftyone.utils.annotations as foua
 from tqdm import tqdm
 
-# TODO: name as param
-dataset = fo.Dataset()
 
 # TODO: as param
 video_path = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
@@ -19,7 +17,6 @@ fouv.reencode_video(video_path, video_path_transformed, verbose=False)
 assert os.path.isfile(video_path)
 
 video_sample = fo.Sample(filepath=video_path)
-print(video_sample)
 
 # TODO: as param
 csv_with_preds = pd.read_csv(
@@ -50,13 +47,14 @@ for frame_idx in tqdm(range(csv_with_preds.shape[0])):  # loop over frames
                     ]
                 ],
                 confidence=csv_with_preds[kp_name]["likelihood"][frame_idx],
-                name=kp_name,
+                label=kp_name,
             )
         )
     video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(keypoints=keypoints_list)
 print("Done.")
 
-
+# TODO: name as param
+dataset = fo.Dataset()
 dataset.add_sample(video_sample)
 dataset.compute_metadata()
 # print(dataset)

--- a/scripts/render_labeled_vids.py
+++ b/scripts/render_labeled_vids.py
@@ -3,40 +3,24 @@ import pandas as pd
 import os
 import fiftyone.utils.annotations as foua
 from tqdm import tqdm
+import hydra
+from omegaconf import DictConfig, OmegaConf
+from pose_est_nets.utils.io import verify_absolute_path
+from pose_est_nets.utils.plotting_utils import get_videos_in_dir
 
 
-# TODO: as param
-video_path = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
-
-"""video_path, if mp4, should be codec h.264. if not:
+"""video_path, if mp4, should be codec h.264. if not, see an example:
 video_path_transformed = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/transformed_test_vid.mp4"
 import fiftyone.utils.video as fouv
 fouv.reencode_video(video_path, video_path_transformed, verbose=False)
 """
 
-assert os.path.isfile(video_path)
 
-video_sample = fo.Sample(filepath=video_path)
-
-# TODO: as param
-csv_with_preds = pd.read_csv(
-    "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv",
-    header=[1, 2],
-)
-
-# TODO: make as params
-height = 406
-width = 396
-
-# Example from fiftyone team
-# fo.Keypoints(keypoints=[fo.Keypoint(points=[[0.5, 0.5]], confidence=0.5), ...])
-# TODO: check how to populate and use the confidence field
-
-keypoint_names = csv_with_preds.columns.levels[0][1:]
-print("Populating the per-frame keypoints...")
-for frame_idx in tqdm(range(csv_with_preds.shape[0])):  # loop over frames
+def make_keypoint_list(
+    csv_with_preds, keypoint_names: list, frame_idx: int, width: int, height: int
+) -> list:
     keypoints_list = []
-    for kp_name in keypoint_names:  # loop over bp names
+    for kp_name in keypoint_names:  # loop over names
         # write a single keypoint's position, confidence, and name
         keypoints_list.append(
             fo.Keypoint(
@@ -50,52 +34,165 @@ for frame_idx in tqdm(range(csv_with_preds.shape[0])):  # loop over frames
                 label=kp_name,
             )
         )
-    video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(keypoints=keypoints_list)
-print("Done.")
+    return keypoints_list
 
-# TODO: name as param
-dataset = fo.Dataset()
-dataset.add_sample(video_sample)
-dataset.compute_metadata()
-# print(dataset)
 
-# TODO: control more params from outside. also for app
-config = foua.DrawConfig(
-    {"keypoints_size": 9}
-)  # note that 9 is approximately 40+ times smaller than the image
+@hydra.main(config_path="configs", config_name="config")
+def render_labeled_videos(cfg: DictConfig):
+    # there may be multiple video paths in the cfg eval
+    # certainly there may be multiple models.
+    # loop over both
+    video_dir = verify_absolute_path(cfg.eval.path_to_test_videos)
+    video = get_videos_in_dir(video_dir)
+    assert (
+        len(video) == 1
+    )  # currently supporting a single file in a directory, TODO: extend and loop
+    path_to_csv_with_preds = verify_absolute_path(cfg.eval.path_to_csv_predictions)
+    csv_with_preds = pd.read_csv(path_to_csv_with_preds, header=[1, 2])
+    keypoint_names = csv_with_preds.columns.levels[0][1:]
+    print("Populating the per-frame keypoints...")
+    video_sample = fo.Sample(filepath=video[0])  # TODO: again extend to multiple vids
+    for frame_idx in tqdm(range(csv_with_preds.shape[0])):  # loop over frames
+        keypoints_list = make_keypoint_list(
+            csv_with_preds=csv_with_preds,
+            keypoint_names=keypoint_names,
+            frame_idx=frame_idx,
+            width=cfg.data.image_orig_dims.width,
+            height=cfg.data.image_orig_dims.height,
+        )
+        # keypoints_list = []
+        # for kp_name in keypoint_names:  # loop over bp names
+        #     # write a single keypoint's position, confidence, and name
+        #     keypoints_list.append(
+        #         fo.Keypoint(
+        #             points=[
+        #                 [
+        #                     csv_with_preds[kp_name]["x"][frame_idx] / width,
+        #                     csv_with_preds[kp_name]["y"][frame_idx] / height,
+        #                 ]
+        #             ],
+        #             confidence=csv_with_preds[kp_name]["likelihood"][frame_idx],
+        #             label=kp_name,
+        #         )
+        #     )
+        video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(
+            keypoints=keypoints_list
+        )
+    print("Done.")
 
-# launch an interactive session
-session = fo.launch_app(dataset, remote=True)
-session.wait()
+    # TODO: name as param
+    dataset = fo.Dataset()
+    dataset.add_sample(video_sample)
+    dataset.compute_metadata()
+    # print(dataset)
 
-# TODO: by definition always save to disk.
-config = foua.DrawConfig({"keypoints_size": 9})
-outpath = "/home/jovyan/vid.mp4"
-print("Writing labeled images to '%s'" % outpath)
-foua.draw_labeled_video(video_sample, outpath, config=config)
-print("Writing complete")
+    # TODO: control more params from outside. also for app
+    config = foua.DrawConfig(
+        {"keypoints_size": 9}
+    )  # note that 9 is approximately 40+ times smaller than the image
 
-# save to disc
+    # launch an interactive session
+    session = fo.launch_app(dataset, remote=True)
+    session.wait()
 
-# inspect frames
-# for frame_number, frame in video_sample.frames.items():
-#     print(frame)
-#     break
+    # TODO: by definition always save to disk.
+    config = foua.DrawConfig({"keypoints_size": 9})
+    outpath = "/home/jovyan/vid_new.mp4"
+    print("Writing labeled images to '%s'" % outpath)
+    foua.draw_labeled_video(video_sample, outpath, config=config)
+    print("Writing complete")
 
-# bodypart_names = csv_with_preds.columns.levels[0][1:]
+
+if __name__ == "__main__":
+    render_labeled_videos()
+
+    # there should be matching csv paths for these vids
+
+
+# # TODO: as param
+# # video_path = "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid.mp4"
+
+
+# video_sample = fo.Sample(filepath=video_path)
+
+# # TODO: as param
+# csv_with_preds = pd.read_csv(
+#     "/home/jovyan/lightning-pose/toy_datasets/toymouseRunningData/unlabeled_videos/test_vid_heatmap.csv",
+#     header=[1, 2],
+# )
+
+# # TODO: make as params
+# height = 406
+# width = 396
+
+# # Example from fiftyone team
+# # fo.Keypoints(keypoints=[fo.Keypoint(points=[[0.5, 0.5]], confidence=0.5), ...])
+# # TODO: check how to populate and use the confidence field
+
+# keypoint_names = csv_with_preds.columns.levels[0][1:]
 # print("Populating the per-frame keypoints...")
 # for frame_idx in tqdm(range(csv_with_preds.shape[0])):  # loop over frames
 #     keypoints_list = []
-#     for bp in bodypart_names:  # loop over bp names
-#         # that's quick but looses body part name labels. works
+#     for kp_name in keypoint_names:  # loop over bp names
+#         # write a single keypoint's position, confidence, and name
 #         keypoints_list.append(
-#             (
-#                 csv_with_preds[bp]["x"][frame_idx] / width,
-#                 csv_with_preds[bp]["y"][frame_idx] / height,
+#             fo.Keypoint(
+#                 points=[
+#                     [
+#                         csv_with_preds[kp_name]["x"][frame_idx] / width,
+#                         csv_with_preds[kp_name]["y"][frame_idx] / height,
+#                     ]
+#                 ],
+#                 confidence=csv_with_preds[kp_name]["likelihood"][frame_idx],
+#                 label=kp_name,
 #             )
 #         )
-#     # # the below used to work note that their indexing starts from 1,
-#     video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(
-#         keypoints=[fo.Keypoint(points=keypoints_list)]
-#     )
+#     video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(keypoints=keypoints_list)
 # print("Done.")
+
+# # TODO: name as param
+# dataset = fo.Dataset()
+# dataset.add_sample(video_sample)
+# dataset.compute_metadata()
+# # print(dataset)
+
+# # TODO: control more params from outside. also for app
+# config = foua.DrawConfig(
+#     {"keypoints_size": 9}
+# )  # note that 9 is approximately 40+ times smaller than the image
+
+# # launch an interactive session
+# session = fo.launch_app(dataset, remote=True)
+# session.wait()
+
+# # TODO: by definition always save to disk.
+# config = foua.DrawConfig({"keypoints_size": 9})
+# outpath = "/home/jovyan/vid.mp4"
+# print("Writing labeled images to '%s'" % outpath)
+# foua.draw_labeled_video(video_sample, outpath, config=config)
+# print("Writing complete")
+
+# # save to disc
+
+# # inspect frames
+# # for frame_number, frame in video_sample.frames.items():
+# #     print(frame)
+# #     break
+
+# # bodypart_names = csv_with_preds.columns.levels[0][1:]
+# # print("Populating the per-frame keypoints...")
+# # for frame_idx in tqdm(range(csv_with_preds.shape[0])):  # loop over frames
+# #     keypoints_list = []
+# #     for bp in bodypart_names:  # loop over bp names
+# #         # that's quick but looses body part name labels. works
+# #         keypoints_list.append(
+# #             (
+# #                 csv_with_preds[bp]["x"][frame_idx] / width,
+# #                 csv_with_preds[bp]["y"][frame_idx] / height,
+# #             )
+# #         )
+# #     # # the below used to work note that their indexing starts from 1,
+# #     video_sample.frames[frame_idx + 1]["preds"] = fo.Keypoints(
+# #         keypoints=[fo.Keypoint(points=keypoints_list)]
+# #     )
+# # print("Done.")

--- a/scripts/train_hydra.py
+++ b/scripts/train_hydra.py
@@ -115,8 +115,10 @@ def train(cfg: DictConfig):
                 torch_seed=cfg.training.rng_seed_model_pt,
             )
         else:
-            print("INVALID DATASET SPECIFIED")
-            exit()
+            raise NotImplementedError(
+                "%s is an invalid cfg.model.model_type for a fully supervised model"
+                % cfg.model.model_type
+            )
 
     else:
         loss_param_dict = OmegaConf.to_object(cfg.losses)
@@ -156,6 +158,11 @@ def train(cfg: DictConfig):
                 loss_params=datamod.loss_param_dict,
                 semi_super_losses_to_use=losses_to_use,
                 torch_seed=cfg.training.rng_seed_model_pt,
+            )
+        else:
+            raise NotImplementedError(
+                "%s is an invalid cfg.model.model_type for a semi-supervised model"
+                % cfg.model.model_type
             )
 
     logger = TensorBoardLogger("tb_logs", name=cfg.model.model_name)

--- a/scripts/train_hydra.py
+++ b/scripts/train_hydra.py
@@ -14,6 +14,7 @@ from pose_est_nets.models.heatmap_tracker import (
     HeatmapTracker,
     SemiSupervisedHeatmapTracker,
 )
+from pose_est_nets.utils.io import get_absolute_data_paths
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import BackboneFinetuning
 from typing import Tuple
@@ -23,39 +24,12 @@ import os
 _TORCH_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
-def get_absolute_toy_data_paths(data_cfg: DictConfig) -> Tuple[str, str]:
-    """function to generate absolute path for our example toy data, wherever lightning-pose may be saved.
-    @hydra.main decorator switches the cwd when executing the decorated function, e.g., our train().
-    so we're in some /outputs/YYYY-MM-DD/HH-MM-SS folder.
-
-    Args:
-        data_cfg (DictConfig): data configuration file with paths to data folder and video folder.
-
-    Returns:
-        Tuple[str, str]: absolute paths to data and video folders.
-    """
-    if os.path.isabs(data_cfg.data_dir):  # both data and video paths are absolute
-        data_dir = data_cfg.data_dir
-        video_dir = data_cfg.video_dir
-    else:  # data_dir path is relative to lightning-pose, and video_dir is relative to data_dir (our toy_datasets)
-        cwd_split = os.getcwd().split(os.path.sep)
-        desired_path_list = cwd_split[:-3]
-        data_dir = os.path.join(os.path.sep, *desired_path_list, data_cfg.data_dir)
-        video_dir = os.path.join(
-            data_dir, data_cfg.video_dir
-        )  # video is inside data_dir
-    # assert that those paths exist and in the proper format
-    assert os.path.isdir(data_dir)
-    assert os.path.isdir(video_dir) or os.path.isfile(video_dir)
-    return data_dir, video_dir
-
-
 @hydra.main(config_path="configs", config_name="config")
 def train(cfg: DictConfig):
     print("Our Hydra config file:")
     print(cfg)
 
-    data_dir, video_dir = get_absolute_toy_data_paths(cfg.data)
+    data_dir, video_dir = get_absolute_data_paths(cfg.data)
 
     data_transform = []
     data_transform.append(

--- a/scripts/train_hydra.py
+++ b/scripts/train_hydra.py
@@ -1,4 +1,3 @@
-from genericpath import isdir
 import pytorch_lightning as pl
 import torch
 import hydra

--- a/scripts/train_hydra.py
+++ b/scripts/train_hydra.py
@@ -1,3 +1,4 @@
+from genericpath import isdir
 import pytorch_lightning as pl
 import torch
 import hydra
@@ -15,16 +16,46 @@ from pose_est_nets.models.heatmap_tracker import (
 )
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import BackboneFinetuning
+from typing import Tuple
 
 import os
 
 _TORCH_DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
 
+def get_absolute_toy_data_paths(data_cfg: DictConfig) -> Tuple[str, str]:
+    """function to generate absolute path for our example toy data, wherever lightning-pose may be saved.
+    @hydra.main decorator switches the cwd when executing the decorated function, e.g., our train().
+    so we're in some /outputs/YYYY-MM-DD/HH-MM-SS folder.
+
+    Args:
+        data_cfg (DictConfig): data configuration file with paths to data folder and video folder.
+
+    Returns:
+        Tuple[str, str]: absolute paths to data and video folders.
+    """
+    if os.path.isabs(data_cfg.data_dir):  # both data and video paths are absolute
+        data_dir = data_cfg.data_dir
+        video_dir = data_cfg.video_dir
+    else:  # data_dir path is relative to lightning-pose, and video_dir is relative to data_dir (our toy_datasets)
+        cwd_split = os.getcwd().split(os.path.sep)
+        desired_path_list = cwd_split[:-3]
+        data_dir = os.path.join(os.path.sep, *desired_path_list, data_cfg.data_dir)
+        video_dir = os.path.join(
+            data_dir, data_cfg.video_dir
+        )  # video is inside data_dir
+    # assert that those paths exist and in the proper format
+    assert os.path.isdir(data_dir)
+    assert os.path.isdir(video_dir) or os.path.isfile(video_dir)
+    return data_dir, video_dir
+
+
 @hydra.main(config_path="configs", config_name="config")
 def train(cfg: DictConfig):
-
+    print("Our Hydra config file:")
     print(cfg)
+
+    data_dir, video_dir = get_absolute_toy_data_paths(cfg.data)
 
     data_transform = []
     data_transform.append(
@@ -38,22 +69,23 @@ def train(cfg: DictConfig):
     imgaug_transform = iaa.Sequential(data_transform)
     if cfg.model.model_type == "regression":
         dataset = BaseTrackingDataset(
-            root_directory=cfg.data.data_dir,
+            root_directory=data_dir,
             csv_path=cfg.data.csv_path,
             header_rows=OmegaConf.to_object(cfg.data.header_rows),
             imgaug_transform=imgaug_transform,
         )
     elif cfg.model.model_type == "heatmap":
         dataset = HeatmapDataset(
-            root_directory=cfg.data.data_dir,
+            root_directory=data_dir,
             csv_path=cfg.data.csv_file,
             header_rows=OmegaConf.to_object(cfg.data.header_rows),
             imgaug_transform=imgaug_transform,
             downsample_factor=cfg.data.downsample_factor,
         )
     else:
-        print("INVALID DATASET SPECIFIED")
-        exit()
+        raise NotImplementedError(
+            "%s is an invalid cfg.model.model_type" % cfg.model.model_type
+        )
 
     if not (cfg.model["semi_supervised"]):
         datamod = BaseDataModule(
@@ -91,7 +123,7 @@ def train(cfg: DictConfig):
         losses_to_use = OmegaConf.to_object(cfg.model.losses_to_use)
         datamod = UnlabeledDataModule(
             dataset=dataset,
-            video_paths_list=cfg.data.video_dir,
+            video_paths_list=video_dir,
             specialized_dataprep=losses_to_use,
             loss_param_dict=loss_param_dict,
             train_batch_size=cfg.training.train_batch_size,

--- a/scripts/train_hydra.py
+++ b/scripts/train_hydra.py
@@ -14,7 +14,7 @@ from pose_est_nets.models.heatmap_tracker import (
     HeatmapTracker,
     SemiSupervisedHeatmapTracker,
 )
-from pose_est_nets.utils.io import get_absolute_data_paths
+from pose_est_nets.utils.io import verify_real_data_paths
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.callbacks import BackboneFinetuning
 from typing import Tuple
@@ -29,7 +29,7 @@ def train(cfg: DictConfig):
     print("Our Hydra config file:")
     print(cfg)
 
-    data_dir, video_dir = get_absolute_data_paths(cfg.data)
+    data_dir, video_dir = verify_real_data_paths(cfg.data)
 
     data_transform = []
     data_transform.append(

--- a/scripts/visualize_frame_preds.py
+++ b/scripts/visualize_frame_preds.py
@@ -124,7 +124,7 @@ def predict(cfg: DictConfig):
         if use_original_model_names:  # the name you gave the model when you trained it
             display_name = model_cfg.model.model_name
         else:  # the new display name from the eval config
-            display_name = cfg.eval.model_names[model_ind]
+            display_name = cfg.eval.model_display_names[model_ind]
 
         ckpt_file = ckpt_path_from_base_path(
             base_path=absolute_cfg_path, model_name=model_name

--- a/scripts/visualize_frame_preds.py
+++ b/scripts/visualize_frame_preds.py
@@ -23,7 +23,7 @@ from pose_est_nets.utils.io import (
     get_absolute_hydra_path_from_hydra_str,
     ckpt_path_from_base_path,
 )
-from pose_est_nets.utils.io import get_absolute_data_paths
+from pose_est_nets.utils.io import verify_real_data_paths
 
 
 def check_eval_model_names(names, hydra_paths) -> bool:
@@ -66,7 +66,9 @@ def check_repeating_model_names(
 @hydra.main(config_path="configs", config_name="config")
 def predict(cfg: DictConfig):
 
-    data_dir, video_dir = get_absolute_data_paths(cfg.data)
+    data_dir, video_dir = verify_real_data_paths(
+        cfg.data
+    )  # if toy dataset with relative paths, make these absolute. otherwise don't change.
 
     # How to transform the images
     data_transform = []

--- a/scripts/visualize_frame_preds.py
+++ b/scripts/visualize_frame_preds.py
@@ -45,7 +45,7 @@ def check_eval_model_names(names, hydra_paths) -> bool:
     return flag
 
 
-def check_old_model_names(
+def check_repeating_model_names(
     model_name: str, model_ind: int, bestmodels: dict, hydra_relative_path
 ) -> str:
     if model_name in bestmodels.keys():
@@ -130,7 +130,7 @@ def predict(cfg: DictConfig):
 
         model = load_model_from_checkpoint(cfg=cfg, ckpt_file=ckpt_file)
 
-        display_name = check_old_model_names(
+        display_name = check_repeating_model_names(
             display_name, model_ind, bestmodels, hydra_relative_path
         )
 

--- a/tests/test_base_resnet.py
+++ b/tests/test_base_resnet.py
@@ -40,6 +40,7 @@ def test_backbone():
                 type(list(model.backbone.children())[-3][-1])
                 == torchvision.models.resnet.Bottleneck
             )
+        torch.cuda.empty_cache()  # remove tensors from gpu
 
 
 def test_representation_shapes_truncated_resnet():
@@ -87,6 +88,7 @@ def test_representation_shapes_truncated_resnet():
             ).to(_TORCH_DEVICE)
             representations = model(fake_image_batch)
             assert representations.shape == shape_list_pre_pool[ind_image][ind]
+    torch.cuda.empty_cache()  # remove tensors from gpu
 
 
 def test_resnet_versions():
@@ -118,3 +120,4 @@ def test_representation_shapes_full_resnet():
             ).to(_TORCH_DEVICE)
             representations = model(fake_image_batch)
             assert representations.shape == repres_shape_list_all_but_fc[ind]
+    torch.cuda.empty_cache()  # remove tensors from gpu

--- a/tests/test_regression_tracker.py
+++ b/tests/test_regression_tracker.py
@@ -89,6 +89,8 @@ def test_forward():
 
 def test_semisupervised():
     # define unsupervised datamodule
+    from pose_est_nets.utils.plotting_utils import get_videos_in_dir
+
     data_transform = []
     data_transform.append(
         iaa.Resize({"height": 384, "width": 384})
@@ -102,12 +104,13 @@ def test_semisupervised():
         imgaug_transform=imgaug_transform,
     )
     video_directory = "toy_datasets/toymouseRunningData/unlabeled_videos"
-    video_files = [video_directory + "/" + f for f in os.listdir(video_directory)]
-    assert os.path.exists(video_files[0])
+    video_files = get_videos_in_dir(video_directory)
 
     # grab example loss config file from repo
     base_dir = os.path.dirname(os.path.dirname(os.path.join(__file__)))
-    loss_cfg = os.path.join(base_dir, "scripts", "configs", "losses", "loss_params.yaml")
+    loss_cfg = os.path.join(
+        base_dir, "scripts", "configs", "losses", "loss_params.yaml"
+    )
     with open(loss_cfg) as f:
         loss_param_dict = yaml.load(f, Loader=yaml.FullLoader)
 
@@ -160,3 +163,6 @@ def test_nan_cleanup():
 
     out = clean_any_nans(data, 0)
     assert (out == clean_data).all()
+
+
+torch.cuda.empty_cache()


### PR DESCRIPTION
* refactored image plotting in fiftyone, now called `visualize_frame_preds.py`
* some fixes in `plotting_utils.py`
* a hydra script for predicting new vids `predict_new_vids.py`
* a hydra script for rendering vids based on csv predictions from multiple models `render_labeled_vids.py`
* style + explanation changes to `README.md`
* fixed some paths in tests
* making sure that the following works: full training -> prediction on train/test/val -> fiftyone -> prediction on new test vids

Open Issues:
* using actual keypoint names in `plotting_utils.py` - should we use a list of bp names to initialize the models themselves, instead of specifying an integer like `num_keypoints=17`?
* deciding on simple conventions like -- how should we name the saved csv, where do we want the labeled videos to be saved?
* extending the `render_labeled_vids.py` script to handle multiple videos or even multiple folders. that depends on the above point.