### PR TITLE
return batches as dicts

### DIFF
--- a/pose_est_nets/datasets/datasets.py
+++ b/pose_est_nets/datasets/datasets.py
@@ -8,7 +8,7 @@ import torch
 from torchvision import transforms
 from typing import Callable, Literal, List, Optional, Tuple, Union, TypedDict
 from torchtyping import TensorType, patch_typeguard
-
+from typeguard import typechecked
 
 from pose_est_nets.utils.dataset_utils import draw_keypoints
 
@@ -22,6 +22,8 @@ _IMAGENET_STD = [0.229, 0.224, 0.225]
 # TODO: review transforms -- resize is done by imgaug.augmenters coming from
 # TODO: the main script. it is fed as input. internally, we always normalize to
 # TODO: imagenet params.
+
+patch_typeguard()  # use before @typechecked
 
 
 class BaseExampleDict(TypedDict):
@@ -132,6 +134,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
     def __len__(self) -> int:
         return len(self.image_names)
 
+    # @typechecked
     def __getitem__(self, idx: int) -> BaseExampleDict:
         # get img_name from self.image_names
         img_name = self.image_names[idx]
@@ -270,6 +273,7 @@ class HeatmapDataset(BaseTrackingDataset):
         self.label_heatmaps = torch.from_numpy(np.asarray(label_heatmaps)).float()
         self.label_heatmaps = self.label_heatmaps.permute(0, 3, 1, 2)
 
+    @typechecked
     def __getitem__(self, idx: int) -> HeatmapExampleDict:
         """Get an example from the dataset.
 

--- a/pose_est_nets/datasets/datasets.py
+++ b/pose_est_nets/datasets/datasets.py
@@ -25,7 +25,7 @@ _IMAGENET_STD = [0.229, 0.224, 0.225]
 
 
 class BaseExampleDict(TypedDict):
-    images: TensorType["RGB":3, "height", "width"]
+    images: TensorType["RGB":3, "image_height", "image_width"]
     keypoints: TensorType[
         "num_targets",
     ]
@@ -39,7 +39,7 @@ class HeatmapExampleDict(BaseExampleDict):
         BaseExampleDict (TypedDict): a dict containing a single example.
     """
 
-    heatmaps: TensorType["num_keypoints", "height", "width"]
+    heatmaps: TensorType["num_keypoints", "heatmap_height", "heatmap_width"]
 
 
 class BaseTrackingDataset(torch.utils.data.Dataset):
@@ -271,7 +271,7 @@ class HeatmapDataset(BaseTrackingDataset):
         self.label_heatmaps = self.label_heatmaps.permute(0, 3, 1, 2)
 
     def __getitem__(self, idx: int) -> HeatmapExampleDict:
-        """Get batch of data.
+        """Get an example from the dataset.
 
         Calls the base dataset to get an image and a label, then additionaly
         return the corresponding heatmap.

--- a/pose_est_nets/datasets/preprocessing.py
+++ b/pose_est_nets/datasets/preprocessing.py
@@ -19,9 +19,9 @@ patch_typeguard()  # use before @typechecked
 
 @typechecked
 def compute_multiview_pca_params(
-        data_module: UnlabeledDataModule,
-        components_to_keep: int = 3,
-        empirical_epsilon_percentile: float = 90.0
+    data_module: UnlabeledDataModule,
+    components_to_keep: int = 3,
+    empirical_epsilon_percentile: float = 90.0,
 ) -> None:
     """Compute eigenvalues and eigenvectors of labeled data for multiview pca loss.
 
@@ -56,8 +56,8 @@ def compute_multiview_pca_params(
         if data_module.dataset.imgaug_transform:
             i = 0
             for idx in indxs:
-                batch = pca_data.__getitem__(idx)
-                data_arr[i] = batch["keypoints"].reshape(-1, 2)
+                batch_dict = pca_data.__getitem__(idx)
+                data_arr[i] = batch_dict["keypoints"].reshape(-1, 2)
                 i += 1
     else:
         data_arr = (
@@ -72,7 +72,7 @@ def compute_multiview_pca_params(
                 ).__getitem__(i)["keypoints"]
 
     # format data and run pca
-    #shape will be (2 * num_views, num_batches * num_keypoints)
+    # shape will be (2 * num_views, num_batches * num_keypoints)
     arr_for_pca = format_multiview_data_for_pca(
         data_arr,
         data_module.loss_param_dict["pca_multiview"]["mirrored_column_matches"],
@@ -91,7 +91,9 @@ def compute_multiview_pca_params(
         dtype=torch.float32,
         device=_TORCH_DEVICE,  # TODO: be careful for multinode
     )
-    data_module.loss_param_dict["pca_multiview"]["discarded_eigenvectors"] = torch.tensor(
+    data_module.loss_param_dict["pca_multiview"][
+        "discarded_eigenvectors"
+    ] = torch.tensor(
         pca.components_[components_to_keep:],
         dtype=torch.float32,
         device=_TORCH_DEVICE,  # TODO: be careful for multinode
@@ -100,7 +102,9 @@ def compute_multiview_pca_params(
     # compute the keypoints' projections on the discarded components, to
     # estimate the e.g., 90th percentile and determine epsilon.
     # absolute value is important -- projections can be negative.
-    discarded_eigs = data_module.loss_param_dict["pca_multiview"]["discarded_eigenvectors"]
+    discarded_eigs = data_module.loss_param_dict["pca_multiview"][
+        "discarded_eigenvectors"
+    ]
     proj_discarded = torch.abs(
         torch.matmul(
             arr_for_pca.T,
@@ -118,10 +122,10 @@ def compute_multiview_pca_params(
         device=_TORCH_DEVICE,  # TODO: be careful for multinode
     )
 
+
 @typechecked
 def compute_singleview_pca_params(
-        data_module: UnlabeledDataModule,
-        empirical_epsilon_percentile: float = 90.0
+    data_module: UnlabeledDataModule, empirical_epsilon_percentile: float = 90.0
 ) -> None:
     """Compute eigenvalues and eigenvectors of labeled data for singleview pca loss.
 
@@ -154,8 +158,8 @@ def compute_singleview_pca_params(
         if data_module.dataset.imgaug_transform:
             i = 0
             for idx in indxs:
-                batch = pca_data.__getitem__(idx)
-                data_arr[i] = batch["keypoints"].reshape(-1, 2)
+                batch_dict = pca_data.__getitem__(idx)
+                data_arr[i] = batch_dict["keypoints"].reshape(-1, 2)
                 i += 1
     else:
         data_arr = (
@@ -170,7 +174,7 @@ def compute_singleview_pca_params(
                 ).__getitem__(i)["keypoints"]
 
     # format data and run pca
-    #shape is (num_batches, num_keypoints * 2)
+    # shape is (num_batches, num_keypoints * 2)
     arr_for_pca = data_arr.reshape(data_arr.shape[0], -1)
     print("Initial array for pca shape: {}".format(arr_for_pca.shape))
 
@@ -178,21 +182,30 @@ def compute_singleview_pca_params(
     print(
         "good_arr_for_pca shape: {}".format(good_arr_for_pca.shape)
     )  # TODO: have prints as tests
-    #want to make sure we have more rows than columns after doing nan filtering
-    assert(good_arr_for_pca.shape[0] >= good_arr_for_pca.shape[1]), "filtered out too many nan frames"
+    # want to make sure we have more rows than columns after doing nan filtering
+    assert (
+        good_arr_for_pca.shape[0] >= good_arr_for_pca.shape[1]
+    ), "filtered out too many nan frames"
     pca = PCA(n_components=good_arr_for_pca.shape[1], svd_solver="full")
     pca.fit(good_arr_for_pca)
     print("Done!")
     tot_explained_variance = np.cumsum(pca.explained_variance_ratio_)
-    components_to_keep = int(np.where(tot_explained_variance >= data_module.loss_param_dict["pca_singleview"]["min_variance_explained"])[0][0])
-    components_to_keep += 1 #cumsum is a d - 1 dimensional vector where the 0th element is the sum of the 0th and 1st element of the d dimensional vector it is summing over
+    components_to_keep = int(
+        np.where(
+            tot_explained_variance
+            >= data_module.loss_param_dict["pca_singleview"]["min_variance_explained"]
+        )[0][0]
+    )
+    components_to_keep += 1  # cumsum is a d - 1 dimensional vector where the 0th element is the sum of the 0th and 1st element of the d dimensional vector it is summing over
     pca_prints(pca, components_to_keep)  # print important params
     data_module.loss_param_dict["pca_singleview"]["kept_eigenvectors"] = torch.tensor(
         pca.components_[:components_to_keep],
         dtype=torch.float32,
         device=_TORCH_DEVICE,  # TODO: be careful for multinode
     )
-    data_module.loss_param_dict["pca_singleview"]["discarded_eigenvectors"] = torch.tensor(
+    data_module.loss_param_dict["pca_singleview"][
+        "discarded_eigenvectors"
+    ] = torch.tensor(
         pca.components_[components_to_keep:],
         dtype=torch.float32,
         device=_TORCH_DEVICE,  # TODO: be careful for multinode
@@ -201,9 +214,11 @@ def compute_singleview_pca_params(
     # compute the keypoints' projections on the discarded components, to
     # estimate the e.g., 90th percentile and determine epsilon.
     # absolute value is important -- projections can be negative.
-    #shape is (num_discarded_components, num_keypoints * 2)
-    discarded_eigs = data_module.loss_param_dict["pca_singleview"]["discarded_eigenvectors"]
-    #array for pca shape is (num_batches, num_keypoints * 2)
+    # shape is (num_discarded_components, num_keypoints * 2)
+    discarded_eigs = data_module.loss_param_dict["pca_singleview"][
+        "discarded_eigenvectors"
+    ]
+    # array for pca shape is (num_batches, num_keypoints * 2)
     proj_discarded = torch.abs(
         torch.matmul(
             arr_for_pca,
@@ -211,7 +226,7 @@ def compute_singleview_pca_params(
         )
     )
     # setting axis = 0 generalizes to multiple discarded components
-    #shape (num_discarded_components, 1)
+    # shape (num_discarded_components, 1)
     epsilon = np.nanpercentile(
         proj_discarded.numpy(), empirical_epsilon_percentile, axis=0
     )
@@ -221,6 +236,7 @@ def compute_singleview_pca_params(
         dtype=torch.float32,
         device=_TORCH_DEVICE,  # TODO: be careful for multinode
     )
+
 
 @typechecked
 def pca_prints(pca: PCA, components_to_keep: int) -> None:
@@ -234,8 +250,8 @@ def pca_prints(pca: PCA, components_to_keep: int) -> None:
 
 @typechecked
 def format_multiview_data_for_pca(
-        data_arr: TensorType["batch", "num_keypoints", "2"],
-        mirrored_column_matches: Union[ListConfig, List],
+    data_arr: TensorType["batch", "num_keypoints", "2"],
+    mirrored_column_matches: Union[ListConfig, List],
 ) -> TensorType["two_time_num_views", "batch_times_num_keypoints"]:
     """
 

--- a/pose_est_nets/datasets/preprocessing.py
+++ b/pose_est_nets/datasets/preprocessing.py
@@ -56,20 +56,20 @@ def compute_multiview_pca_params(
         if data_module.dataset.imgaug_transform:
             i = 0
             for idx in indxs:
-                vals = pca_data.__getitem__(idx)
-                data_arr[i] = vals[1].reshape(-1, 2)
+                batch = pca_data.__getitem__(idx)
+                data_arr[i] = batch["keypoints"].reshape(-1, 2)
                 i += 1
     else:
         data_arr = (
             data_module.train_dataset.keypoints.detach().clone()
         )  # won't work for random splitting
 
-        # apply augmentation which *downsamples* the frames
+        # apply augmentation which *downsamples* the frames/keypoints
         if data_module.train_dataset.imgaug_transform:
             for i in range(len(data_arr)):
                 data_arr[i] = super(
                     type(data_module.train_dataset), data_module.train_dataset
-                ).__getitem__(i)[1]
+                ).__getitem__(i)["keypoints"]
 
     # format data and run pca
     #shape will be (2 * num_views, num_batches * num_keypoints)
@@ -150,12 +150,12 @@ def compute_singleview_pca_params(
             data_module.dataset.keypoints.detach().clone(), 0, indxs
         )  # data_arr is shape (train_batches, keypoints, 2)
 
-        # apply augmentation which *downsamples* the frames
+        # apply augmentation which *downsamples* the frames/keypoints
         if data_module.dataset.imgaug_transform:
             i = 0
             for idx in indxs:
-                vals = pca_data.__getitem__(idx)
-                data_arr[i] = vals[1].reshape(-1, 2)
+                batch = pca_data.__getitem__(idx)
+                data_arr[i] = batch["keypoints"].reshape(-1, 2)
                 i += 1
     else:
         data_arr = (
@@ -167,7 +167,7 @@ def compute_singleview_pca_params(
             for i in range(len(data_arr)):
                 data_arr[i] = super(
                     type(data_module.train_dataset), data_module.train_dataset
-                ).__getitem__(i)[1]
+                ).__getitem__(i)["keypoints"]
 
     # format data and run pca
     #shape is (num_batches, num_keypoints * 2)

--- a/pose_est_nets/models/heatmap_tracker.py
+++ b/pose_est_nets/models/heatmap_tracker.py
@@ -206,49 +206,46 @@ class HeatmapTracker(BaseFeatureExtractor):
         return heatmaps
 
     @typechecked
-    def training_step(self, data_batch: List, batch_idx: int) -> dict:
-        images, true_heatmaps, true_keypoints = data_batch  # read batch
-        predicted_heatmaps = self.forward(images)  # images -> heatmaps
+    def training_step(self, data_batch: Dict, batch_idx: int) -> Dict:
+
+        # forward pass
+        predicted_heatmaps = self.forward(data_batch["images"])  # images -> heatmaps
         predicted_keypoints, confidence = self.run_subpixelmaxima(
             predicted_heatmaps
         )  # heatmaps -> keypoints
-        heatmap_loss = MaskedMSEHeatmapLoss(true_heatmaps, predicted_heatmaps)
-        supervised_rmse = MaskedRMSELoss(true_keypoints, predicted_keypoints)
-        self.log(
-            "train_loss",
-            heatmap_loss,
-            prog_bar=True,
-        )
-        self.log(
-            "supervised_rmse",
-            supervised_rmse,
-            prog_bar=True,
-        )
+
+        # compute loss
+        heatmap_loss = MaskedMSEHeatmapLoss(data_batch["heatmaps"], predicted_heatmaps)
+        supervised_rmse = MaskedRMSELoss(data_batch["keypoints"], predicted_keypoints)
+
+        # log training loss + rmse
+        self.log("train_loss", heatmap_loss, prog_bar=True)
+        self.log("supervised_rmse", supervised_rmse, prog_bar=True)
+
         return {"loss": heatmap_loss}
 
     @typechecked
     def evaluate(
-        self, data_batch: List, stage: Optional[Literal["val", "test"]] = None
-    ):
-        images, true_heatmaps, true_keypoints = data_batch  # read batch
-        predicted_heatmaps = self.forward(images)  # images -> heatmaps
+        self,
+        data_batch: Dict,
+        stage: Optional[Literal["val", "test"]] = None
+    ) -> None:
+        predicted_heatmaps = self.forward(data_batch["images"])  # images -> heatmaps
         predicted_keypoints, confidence = self.run_subpixelmaxima(
             predicted_heatmaps
         )  # heatmaps -> keypoints
-        loss = MaskedMSEHeatmapLoss(true_heatmaps, predicted_heatmaps)
-        supervised_rmse = MaskedRMSELoss(true_keypoints, predicted_keypoints)
-
-        # TODO: do we need other metrics?
+        loss = MaskedMSEHeatmapLoss(data_batch["heatmaps"], predicted_heatmaps)
+        supervised_rmse = MaskedRMSELoss(data_batch["keypoints"], predicted_keypoints)
         if stage:
             self.log(f"{stage}_loss", loss, prog_bar=True, logger=True)
             self.log(
                 f"{stage}_supervised_rmse", supervised_rmse, prog_bar=True, logger=True
             )
 
-    def validation_step(self, validation_batch: List, batch_idx):
+    def validation_step(self, validation_batch: Dict, batch_idx):
         self.evaluate(validation_batch, "val")
 
-    def test_step(self, test_batch: List, batch_idx):
+    def test_step(self, test_batch: Dict, batch_idx):
         self.evaluate(test_batch, "test")
 
 
@@ -315,28 +312,39 @@ class SemiSupervisedHeatmapTracker(HeatmapTracker):
         self.loss_params = loss_params
 
     @typechecked
-    def training_step(self, data_batch: dict, batch_idx: int) -> dict:
-        labeled_imgs, true_heatmaps, true_keypoints = data_batch["labeled"]
-        unlabeled_imgs = data_batch["unlabeled"]
-        predicted_heatmaps = self.forward(labeled_imgs)
-        supervised_loss = MaskedMSEHeatmapLoss(true_heatmaps, predicted_heatmaps)
+    def training_step(self, data_batch: Dict, batch_idx: int) -> Dict:
+
+        # forward pass labeled
+        predicted_heatmaps = self.forward(data_batch["labeled"]['images'])
         predicted_keypoints, confidence = self.run_subpixelmaxima(
             predicted_heatmaps
         )  # heatmaps -> keypoints
-        supervised_rmse = MaskedRMSELoss(true_keypoints, predicted_keypoints)
-        unlabeled_predicted_heatmaps = self.forward(unlabeled_imgs)
+
+        # compute loss labeled
+        supervised_loss = MaskedMSEHeatmapLoss(
+            data_batch["labeled"]["heatmaps"],
+            predicted_heatmaps
+        )
+        supervised_rmse = MaskedRMSELoss(
+            data_batch["labeled"]["keypoints"],
+            predicted_keypoints
+        )
+
+        # forward pass unlabeled
+        unlabeled_predicted_heatmaps = self.forward(data_batch["unlabeled"])
         predicted_us_keypoints, confidence = self.run_subpixelmaxima(
             unlabeled_predicted_heatmaps
         )
+
+        # loop over unsupervised losses
         tot_loss = 0.0
         tot_loss += supervised_loss
-        # loop over unsupervised losses
         self.loss_params = convert_dict_entries_to_tensors(
             self.loss_params, self.device
         )
         for loss_name, loss_func in self.loss_function_dict.items():
-            #Some losses use keypoint_preds, some use heatmap_preds, and some use both. 
-            #all have **kwargs so are robust to unneeded inputs."
+            # Some losses use keypoint_preds, some use heatmap_preds, and some use both.
+            # all have **kwargs so are robust to unneeded inputs."
             add_loss = self.loss_params[loss_name]["weight"] * loss_func(
                 keypoint_preds = predicted_us_keypoints, 
                 heatmap_preds = unlabeled_predicted_heatmaps,
@@ -344,24 +352,11 @@ class SemiSupervisedHeatmapTracker(HeatmapTracker):
             )
             tot_loss += add_loss
             # log individual unsupervised losses
-            self.log(
-                loss_name + "_loss",
-                add_loss,
-                prog_bar=True,
-            )
-        self.log(
-            "total_loss",
-            tot_loss,
-            prog_bar=True,
-        )
-        self.log(
-            "supervised_loss",
-            supervised_loss,
-            prog_bar=True,
-        )
-        self.log(
-            "supervised_rmse",
-            supervised_rmse,
-            prog_bar=True,
-        )
+            self.log(loss_name + "_loss", add_loss, prog_bar=True)
+
+        # log other losses
+        self.log("total_loss", tot_loss, prog_bar=True)
+        self.log("supervised_loss", supervised_loss, prog_bar=True)
+        self.log("supervised_rmse", supervised_rmse, prog_bar=True)
+
         return {"loss": tot_loss}

--- a/pose_est_nets/models/heatmap_tracker.py
+++ b/pose_est_nets/models/heatmap_tracker.py
@@ -23,9 +23,7 @@ from pose_est_nets.utils.heatmap_tracker_utils import (
 from pose_est_nets.models.regression_tracker import BaseBatchDict
 
 
-patch_typeguard()  # use before @typechecked
-
-
+@typechecked
 class HeatmapBatchDict(BaseBatchDict):
     """Inherets key-value pairs from BaseExampleDict and adds "heatmaps"
 
@@ -33,10 +31,19 @@ class HeatmapBatchDict(BaseBatchDict):
         BaseExampleDict (TypedDict): a dict containing a single example.
     """
 
-    heatmaps: TensorType["batch", "num_keypoints", "heatmap_height", "heatmap_width"]
+    heatmaps: TensorType[
+        "batch", "num_keypoints", "heatmap_height", "heatmap_width", float
+    ]
 
 
-# TODO: add batch for semisupervised
+class SemiSupervisedHeatmapBatchDict(TypedDict):
+    labeled: HeatmapBatchDict
+    unlabeled: TensorType[
+        "sequence_length", "RGB":3, "image_height", "image_width", float
+    ]
+
+
+patch_typeguard()  # use before @typechecked
 
 
 @typechecked
@@ -328,7 +335,9 @@ class SemiSupervisedHeatmapTracker(HeatmapTracker):
         self.loss_params = loss_params
 
     @typechecked
-    def training_step(self, data_batch: Dict, batch_idx: int) -> Dict:
+    def training_step(
+        self, data_batch: SemiSupervisedHeatmapBatchDict, batch_idx: int
+    ) -> Dict:
 
         # forward pass labeled
         predicted_heatmaps = self.forward(data_batch["labeled"]["images"])

--- a/pose_est_nets/models/regression_tracker.py
+++ b/pose_est_nets/models/regression_tracker.py
@@ -60,6 +60,10 @@ class RegressionTracker(BaseFeatureExtractor):
         self.torch_seed = torch_seed
         self.save_hyperparameters()
 
+    @property
+    def num_keypoints(self):
+        return self.num_targets // 2
+
     @staticmethod
     @typechecked
     def reshape_representation(
@@ -171,6 +175,10 @@ class SemiSupervisedRegressionTracker(RegressionTracker):
             torch_seed=torch_seed,
         )
         print(semi_super_losses_to_use)
+        if semi_super_losses_to_use is None:
+            raise ValueError("must specify losses for unlabeled frames")
+        if "unimodal" in semi_super_losses_to_use:
+            raise ValueError("cannot use unimodal loss in regression tracker")
         self.loss_function_dict = get_losses_dict(semi_super_losses_to_use)
         self.loss_params = loss_params
 

--- a/pose_est_nets/utils/fiftyone_plotting_utils.py
+++ b/pose_est_nets/utils/fiftyone_plotting_utils.py
@@ -77,7 +77,7 @@ def make_dataset_and_evaluate(cfg: DictConfig, datamod: Callable, best_models: d
         sample["ground_truth"] = fo.Keypoints(
             keypoints=[fo.Keypoint(points=ground_truth_kpts_list)]
         )
-        img = datamod.dataset.__getitem__(idx)[0].unsqueeze(0)
+        img = datamod.dataset.__getitem__(idx)["images"].unsqueeze(0)
         img_BHWC = img.permute(0, 2, 3, 1)  # Needs to be BHWC format
         with torch.no_grad():
             for name, model in best_models.items():

--- a/pose_est_nets/utils/plotting_utils.py
+++ b/pose_est_nets/utils/plotting_utils.py
@@ -438,6 +438,7 @@ def predict_videos(
         else:
             raise NotImplementedError("Currently only .csv and .h5 files are supported")
 
-        # if iterating over multiple models, outside this function, the below will reduce memory
-        del model, pipe, predict_loader
-        torch.cuda.empty_cache()
+    # if iterating over multiple models, outside this function, the below will reduce
+    # memory
+    del model, pipe, predict_loader
+    torch.cuda.empty_cache()

--- a/pose_est_nets/utils/wrappers.py
+++ b/pose_est_nets/utils/wrappers.py
@@ -19,16 +19,15 @@ def predict_plot_test_epoch(model,
     model.eval()
     counter = 0
     for batch in dataloader:
-        images, labels = batch
-        predictions = model(images)
+        predictions = model(batch["images"])
 
         for i in range(images.shape[0]):
-            scatter_predictions(images[i], labels[i], predictions[i])
+            scatter_predictions(images[i], batch["labels"][i], predictions[i])
             plt.savefig(os.path.join(preds_folder, "test_im_" + str(counter) + ".png"))
             plt.close()
             preds_dict["preds"].append(predictions[i])
             preds_dict["labels"].append(labels[i])
-            counter+=1
+            counter += 1
 
     save_object(preds_dict, os.path.join(preds_folder, "preds"))
 
@@ -41,4 +40,3 @@ def scatter_predictions(image: torch.Tensor, labels: torch.Tensor, preds: torch.
     plt.imshow(image[0])
     plt.scatter(labels[0::2], labels[1::2], label='labels')
     plt.scatter(preds[0::2], preds[1::2], label='preds')
-

--- a/scripts/configs/data/data_params.yaml
+++ b/scripts/configs/data/data_params.yaml
@@ -18,7 +18,7 @@ video_dir: "unlabeled_videos"
 csv_file: "CollectedData_.csv"
 
 # header rows to strip in label csv file
-header_rows: [1, 2]
+header_rows: [0, 1]
 
 # downsample heatmaps: 2 | 3
 downsample_factor: 2

--- a/tests/test_datamodules.py
+++ b/tests/test_datamodules.py
@@ -23,13 +23,11 @@ imgaug_transform = iaa.Sequential(data_transform)
 video_directory = "toy_datasets/toymouseRunningData/unlabeled_videos"
 assert os.path.exists(video_directory)
 
+# video_directory may contain other random files that are not vids, DALI will try to
+# read them
 video_files = [video_directory + "/" + f for f in os.listdir(video_directory)]
 vids = []
-for (
-    f
-) in (
-    video_files
-):  # video_directory may contain other random files that are not vids, DALI will try to read them
+for f in video_files:
     if f.endswith(".mp4"):  # hardcoded for the toydataset folder
         vids.append(f)
 
@@ -64,22 +62,23 @@ def test_base_datamodule():
     reg_module.setup()
     batch = next(iter(reg_module.train_dataloader()))
     assert (
-        torch.tensor(batch[0].shape)
+        torch.tensor(batch["images"].shape)
         == torch.tensor([reg_module.train_batch_size, 3, 384, 384])
     ).all()
     assert (
-        torch.tensor(batch[1].shape) == torch.tensor([reg_module.train_batch_size, 34])
+        torch.tensor(batch["keypoints"].shape) ==
+        torch.tensor([reg_module.train_batch_size, 34])
     ).all()
 
     heatmap_module = BaseDataModule(heatmap_data)  # and default args
     heatmap_module.setup()
     batch = next(iter(heatmap_module.train_dataloader()))
     assert (
-        torch.tensor(batch[0].shape)
+        torch.tensor(batch["images"].shape)
         == torch.tensor([heatmap_module.train_batch_size, 3, 384, 384])
     ).all()
     assert (
-        torch.tensor(batch[1].shape)
+        torch.tensor(batch["heatmaps"].shape)
         == torch.tensor(
             [
                 heatmap_module.train_batch_size,
@@ -199,7 +198,7 @@ def test_PCA():  # TODO FINISH WRITING TEST
         heatmap_data,
         video_paths_list=vids,
         loss_param_dict=loss_param_dict,
-        losses_to_use="pca_multiview",
+        losses_to_use=["pca_multiview"],
     )
     # remove model/data from gpu; then cache can be cleared
     del unlabeled_module_heatmap

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -16,55 +16,47 @@ def test_heatmap_dataset():
     )  # dlc dimensions need to be repeatably divisable by 2
     imgaug_transform = iaa.Sequential(data_transform)
 
-    regData = BaseTrackingDataset(
+    regression_data = BaseTrackingDataset(
         root_directory="toy_datasets/toymouseRunningData",
         csv_path="CollectedData_.csv",
         header_rows=[1, 2],
         imgaug_transform=imgaug_transform,
     )
-    heatmapData = HeatmapDataset(
+    heatmap_data = HeatmapDataset(
         root_directory="toy_datasets/toymouseRunningData",
         csv_path="CollectedData_.csv",
         header_rows=[1, 2],
         imgaug_transform=imgaug_transform,
     )
     # first test: both datasets provide the same image at index 0
-    assert torch.equal(regData[0][0], heatmapData[0][0])
+    assert torch.equal(regression_data[0]["images"], heatmap_data[0]["images"])
 
     # we get the desired image height and width
-    assert heatmapData[0][0].shape[1:] == (
-        heatmapData.height,
-        heatmapData.width,
+    assert (
+            heatmap_data[0]["images"].shape[1:] ==
+            (heatmap_data.height, heatmap_data.width)
     )
-    image, heatmaps, keypoints = heatmapData[0]
-    assert image.shape == (3, 384, 384)  # resized image shape
-    assert keypoints.shape == (34,)
-    assert heatmaps.shape[1:] == heatmapData.output_shape
-    assert type(regData[0][1]) == torch.Tensor
-    numKeypoints = regData.keypoints.shape[1]
+    assert heatmap_data[0]["images"].shape == (3, 384, 384)  # resized image shape
+    assert heatmap_data[0]["keypoints"].shape == (34,)
+    assert heatmap_data[0]["heatmaps"].shape[1:] == heatmap_data.output_shape
+    assert type(regression_data[0]["keypoints"]) == torch.Tensor
 
     # for idx in range(numLabels):
-    #     if torch.any(torch.isnan(regData.__getitem__(0)[1][idx])):
+    #     if torch.any(torch.isnan(regression_data.__getitem__(0)[1][idx])):
     #         print("there is any nan here")
-    #         print(torch.max(heatmapData.__getitem__(0)[1][idx]))
-    #         assert torch.max(heatmapData.__getitem__(0)[1][idx]) == torch.tensor(0)
+    #         print(torch.max(heatmap_data.__getitem__(0)[1][idx]))
+    #         assert torch.max(heatmap_data.__getitem__(0)[1][idx]) == torch.tensor(0)
     #     else:  # TODO: the below isn't passing on idx 5, we have an all zeros heatmap for a label vec without nans
     #         print(f"idx {idx}")
     #         print("no nan's here")
     #         print("labels: {}")
-    #         print(torch.unique(heatmapData.__getitem__(0)[1][idx]))
-    #         print("item {}".format(torch.max(heatmapData.__getitem__(0)[1][idx])))
-    #         assert torch.max(heatmapData.__getitem__(0)[1][idx]) != torch.tensor(0)
+    #         print(torch.unique(heatmap_data.__getitem__(0)[1][idx]))
+    #         print("item {}".format(torch.max(heatmap_data.__getitem__(0)[1][idx])))
+    #         assert torch.max(heatmap_data.__getitem__(0)[1][idx]) != torch.tensor(0)
 
-    # print(heatmapData.__getitem__(11)[1])
+    # print(heatmap_data.__getitem__(11)[1])
 
     # remove model/data from gpu; then cache can be cleared
-    del regData
-    del heatmapData
-    del image
-    del heatmaps
-    del keypoints
+    del regression_data
+    del heatmap_data
     torch.cuda.empty_cache()  # remove tensors from gpu
-
-
-test_heatmap_dataset()

--- a/tests/test_heatmap.py
+++ b/tests/test_heatmap.py
@@ -139,7 +139,7 @@ def test_unsupervised():  # TODO Finish writing test
     datamod = UnlabeledDataModule(
         dataset=dataset,
         video_paths_list=vids[0],
-        losses_to_use="pca_multiview",
+        losses_to_use=["pca_multiview"],
         loss_param_dict=loss_param_dict,
     )
     datamod.setup()
@@ -157,10 +157,10 @@ def test_unsupervised():  # TODO Finish writing test
     assert list(out.keys())[0] == "labeled"
     assert list(out.keys())[1] == "unlabeled"
     assert out["unlabeled"].shape == (datamod.train_batch_size, 3, 384, 384,)
-    print(out["labeled"][0].device)
+    print(out["labeled"]["images"].device)
     print(out["unlabeled"].device)
     print(model.device)
-    out_heatmaps_labeled = model.forward(out["labeled"][0].to(_TORCH_DEVICE))
+    out_heatmaps_labeled = model.forward(out["labeled"]["images"].to(_TORCH_DEVICE))
     out_heatmaps_unlabeled = model.forward(out["unlabeled"])
 
     assert out_heatmaps_labeled.shape == (

--- a/tests/test_regression_tracker.py
+++ b/tests/test_regression_tracker.py
@@ -126,7 +126,7 @@ def test_semisupervised():
     datamod = UnlabeledDataModule(
         dataset=dataset,
         video_paths_list=video_files[0],
-        losses_to_use="pca_multiview",
+        losses_to_use=["pca_multiview"],
         loss_param_dict=loss_param_dict,
         train_batch_size=4,
     )

--- a/tests/test_regression_tracker.py
+++ b/tests/test_regression_tracker.py
@@ -88,6 +88,7 @@ def test_forward():
     del model
     del representations
     del preds
+
     torch.cuda.empty_cache()  # remove tensors from gpu
 
 
@@ -119,7 +120,8 @@ def test_semisupervised():
         loss_param_dict = yaml.load(f, Loader=yaml.FullLoader)
     # hard code multivew pca info for now
     loss_param_dict["pca_multiview"]["mirrored_column_matches"] = [
-        [0, 1, 2, 3, 4, 5, 6], [8, 9, 10, 11, 12, 13, 14]
+        [0, 1, 2, 3, 4, 5, 6],
+        [8, 9, 10, 11, 12, 13, 14],
     ]
 
     semi_super_losses_to_use = ["pca_multiview"]

--- a/tests/test_subpixmaxima.py
+++ b/tests/test_subpixmaxima.py
@@ -30,33 +30,30 @@ def test_subpixmaxima():
         threshold=None,
         device=_TORCH_DEVICE
     )
-    test_img, gt_heatmap, gt_keypts = dataset.__getitem__(idx=0)
-    maxima, confidence = SubPixMax.run(gt_heatmap.unsqueeze(0).to(_TORCH_DEVICE))
+    batch = dataset.__getitem__(idx=0)
+    maxima, confidence = SubPixMax.run(batch["heatmaps"].unsqueeze(0).to(_TORCH_DEVICE))
     maxima = maxima.squeeze(0)
-    assert(maxima.shape == gt_keypts.shape)
+    assert(maxima.shape == batch["keypoints"].shape)
     assert(maxima.shape[0]//2 == confidence.shape[1])
 
     # remove model/data from gpu; then cache can be cleared
-    del gt_heatmap
-    del test_img, gt_keypts
+    del batch
     del maxima, confidence
     torch.cuda.empty_cache()  # remove tensors from gpu
 
     dl = DataLoader(dataset, batch_size=2)
-    img_batch, gt_heatmap_batch, gt_keypts_batch = next(iter(dl))
-
+    batch = next(iter(dl))
     del dataset
     del dl
-    del img_batch, gt_keypts_batch
     torch.cuda.empty_cache()  # remove tensors from gpu
     
     maxima1, confidence1 = SubPixMax.run(
-        gt_heatmap_batch.to(_TORCH_DEVICE)   
+        batch["heatmaps"].to(_TORCH_DEVICE)
     )
     print(maxima1.shape, confidence1.shape)
 
     # remove model/data from gpu; then cache can be cleared
-    del gt_heatmap_batch
+    del batch
     del maxima1, confidence1
     torch.cuda.empty_cache()  # remove tensors from gpu
 
@@ -73,12 +70,17 @@ def test_generate_keypoints():
         header_rows=[1, 2],
         imgaug_transform=imgaug_transform,
     )
-    test_img, gt_heatmap, gt_keypts = dataset.__getitem__(idx=0)
-    assert(gt_keypts.shape == (torch.Size([34])))
-    gt_heatmap = gt_heatmap.unsqueeze(0)
-    gt_keypts = gt_keypts.unsqueeze(0).reshape(1, 17, 2)
+    batch = dataset.__getitem__(idx=0)
+    assert(batch["keypoints"].shape == (torch.Size([34])))
+    gt_heatmap = batch["heatmaps"].unsqueeze(0)
+    gt_keypts = batch["keypoints"].unsqueeze(0).reshape(1, 17, 2)
     assert(gt_heatmap.shape == (1, 17, 96, 96))
-    torch_heatmap = generate_heatmaps(gt_keypts, height=384, width=384, output_shape=(96,96))
+    torch_heatmap = generate_heatmaps(
+        gt_keypts,
+        height=384,
+        width=384,
+        output_shape=(96, 96)
+    )
     SubPixMax = SubPixelMaxima(
         output_shape=(96, 96),
         output_sigma=torch.tensor(1.25, device=_TORCH_DEVICE),
@@ -93,11 +95,20 @@ def test_generate_keypoints():
     assert(og_maxima == torch_maxima).all()
     assert(gt_confidence == confidence_t).all()
 
+    # remove model/data from gpu; then cache can be cleared
+    del batch
+    del gt_heatmap, gt_keypts
+    torch.cuda.empty_cache()  # remove tensors from gpu
+
+
 def test_generate_keypoints_weird_shape():
     data_transform = []
     OG_SHAPE = (384, 256)
     DOWNSAMPLE_FACTOR = 2
-    output_shape = (OG_SHAPE[0]//(2** DOWNSAMPLE_FACTOR), OG_SHAPE[1]//(2** DOWNSAMPLE_FACTOR))
+    output_shape = (
+        OG_SHAPE[0]//(2**DOWNSAMPLE_FACTOR),
+        OG_SHAPE[1]//(2**DOWNSAMPLE_FACTOR)
+    )
     data_transform.append(
         iaa.Resize({"height": OG_SHAPE[0], "width": OG_SHAPE[1]})
     )  # dlc dimensions need to be repeatably divisable by 2
@@ -108,12 +119,17 @@ def test_generate_keypoints_weird_shape():
         header_rows=[1, 2],
         imgaug_transform=imgaug_transform,
     )
-    test_img, gt_heatmap, gt_keypts = dataset.__getitem__(idx=0)
-    assert(gt_keypts.shape == (torch.Size([34])))
-    gt_heatmap = gt_heatmap.unsqueeze(0)
-    gt_keypts = gt_keypts.unsqueeze(0).reshape(1, 17, 2)
+    batch = dataset.__getitem__(idx=0)
+    assert(batch["keypoints"].shape == (torch.Size([34])))
+    gt_heatmap = batch["heatmaps"].unsqueeze(0)
+    gt_keypts = batch["keypoints"].unsqueeze(0).reshape(1, 17, 2)
     assert(gt_heatmap.shape == (1, 17, output_shape[0], output_shape[1]))
-    torch_heatmap = generate_heatmaps(gt_keypts, height=OG_SHAPE[0], width=OG_SHAPE[1], output_shape=output_shape)
+    torch_heatmap = generate_heatmaps(
+        gt_keypts,
+        height=OG_SHAPE[0],
+        width=OG_SHAPE[1],
+        output_shape=output_shape
+    )
     SubPixMax = SubPixelMaxima(
         output_shape=output_shape,
         output_sigma=torch.tensor(1.25, device=_TORCH_DEVICE),
@@ -128,9 +144,11 @@ def test_generate_keypoints_weird_shape():
     assert(og_maxima == torch_maxima).all()
     assert(gt_confidence == confidence_t).all()
 
-#tests the batched functionality of generate_heatmaps by comparing it to the ground truth heatmaps
-#in the heatmap dataset computed by the previous numpy function draw_keypoints. 
-#TODO: Change ground truth computation of heatmaps for heatmap dataset to use generate_heatmaps.
+
+# tests the batched functionality of generate_heatmaps by comparing it to the ground
+# truth heatmaps in the heatmap dataset computed by the previous numpy function draw_
+# keypoints.
+# TODO: Change gt computation of heatmaps for heatmap dataset to use generate_heatmaps.
 def test_generate_keypoints_batched():
     data_transform = []
     data_transform.append(
@@ -154,16 +172,15 @@ def test_generate_keypoints_batched():
         device=_TORCH_DEVICE
     )
     for batch in dl:
-        _, gt_heatmaps, gt_keypts = batch
-        gt_keypts = gt_keypts.reshape(-1, 17, 2)
-        heatmaps = generate_heatmaps(gt_keypts, height=384, width=384, output_shape=(96,96))
-        gt_maxima, gt_confidence = SubPixMax.run(gt_heatmaps.to(_TORCH_DEVICE))
+        gt_keypts = batch["keypoints"].reshape(-1, 17, 2)
+        heatmaps = generate_heatmaps(
+            gt_keypts,
+            height=384,
+            width=384,
+            output_shape=(96, 96)
+        )
+        gt_maxima, gt_confidence = SubPixMax.run(batch["heatmaps"].to(_TORCH_DEVICE))
         torch_maxima, confidence_t = SubPixMax.run(heatmaps.to(_TORCH_DEVICE))
         assert(gt_maxima == torch_maxima).all()
-        loss = MaskedMSEHeatmapLoss(gt_heatmaps, heatmaps)
+        loss = MaskedMSEHeatmapLoss(batch["heatmaps"], heatmaps)
         assert(loss < 1e-6)
-        # bad_idx = ~(gt_confidence == confidence_t)
-        # print(gt_confidence[bad_idx])
-        # print(confidence_t[bad_idx])
-        #assert(gt_confidence == confidence_t).all() #seem to have inperceptible differences (maybe in hidden decimal places)
-


### PR DESCRIPTION
Instead of returning batches as lists, return them as dicts so that access is cleaner
images = batch["images"]
instead of 
images = batch[0]

Data loaders now also return the image index