### PR TITLE
add eval.fiftyone.remote

### DIFF
--- a/scripts/configs/eval/eval_params.yaml
+++ b/scripts/configs/eval/eval_params.yaml
@@ -13,6 +13,7 @@ fiftyone:
   # whether to launch the app from the script (True), or from ipython (and have finer control over the outputs)
   launch_app_from_script: False
 
+  remote: True # for LAI, must be False
   address: 127.0.0.1 # ip to launch the app on.
   port: 5151 # port to launch the app on.
 

--- a/scripts/create_fiftyone_dataset.py
+++ b/scripts/create_fiftyone_dataset.py
@@ -29,7 +29,7 @@ def build_fo_dataset(cfg: DictConfig) -> None:
 
     if cfg.eval.fiftyone.launch_app_from_script:
         # launch an interactive session
-        session = fo.launch_app(dataset, remote=True, address=cfg.eval.fiftyone.address, port=cfg.eval.fiftyone.port)
+        session = fo.launch_app(dataset, remote=cfg.eval.fiftyone.remote, address=cfg.eval.fiftyone.address, port=cfg.eval.fiftyone.port)
         session.wait()
     # otherwise launch from an ipython session
 


### PR DESCRIPTION
add control so that eval.fiftyone.remote=False can be used as required

	modified:   scripts/configs/eval/eval_params.yaml
	modified:   scripts/create_fiftyone_dataset.py