### PR TITLE
Feature/streamlit model select

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -1,19 +1,21 @@
 # Labeled Frame Diagnostics
 
 Analyze predictions of one or more networks on the `train/test/val` images.
+From within `.../lightning-pose/lightning_pose/apps`, run:
 ```
 streamlit run labeled_frame_diagnostics.py -- --model_dir <ABOLUTE_PATH_TO_HYDRA_OUTPUTS_DIRECTORY>
 ```
-The only argument needed is `--model_dir`, which tells the app where to find models and their predictions. `<HYDRA_OUTPUTS_DIRECTORY>` should contain hydra subfolders of the type `YYYY-MM-DD/HH-MM-SS`.
+The only argument needed is `--model_dir`, which tells the app where to find models and their predictions. `<ABOLUTE_PATH_TO_HYDRA_OUTPUTS_DIRECTORY>` should contain hydra subfolders of the type `YYYY-MM-DD/HH-MM-SS`.
 
 (The lightning-pose output folder for a single model is typically: `/path/to/lightning-pose/outputs/YYYY-MM-DD/HH-MM-SS`, where inside the last folder there are prediction `.csv`s.)
 
 The app shows:
-    - plot of a selected metric (e.g. pixel errors, confidences) for each network and each body part, using bar/box/violin/etc plots.
-    - scatterplot of a selected metric between two networks
+- plot of a selected metric (e.g. pixel errors, confidences) for each network and each body part, using bar/box/violin/etc plots.
+- scatterplot of a selected metric between two networks
 
 # Video Diagnostics
 Visualizes multiple networks' predictions on a test video.
+From within `.../lightning-pose/lightning_pose/apps`, run:
 ```
 streamlit run video_diagnostics.py -- --model_dir <ABOLUTE_PATH_TO_HYDRA_OUTPUTS_DIRECTORY>
 ```

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -1,41 +1,23 @@
 # Labeled Frame Diagnostics
-You can analyze predictions of one or multiple trained models on the `train/test/val` images using this streamlit app.
 
-The app creates plots for:
-    - plot of a selected metric (e.g. pixel errors) for each model (bar/box/violin/etc)
-    - scatterplot of a selected metric between two models
-
-### Specifying models to compare
-Users select an arbitrary number of model output folders and pass these through the command line to compute metrics for each of these models. Users can also specify names for each of these models using command line arguments. The two command line arguments taken by this streamlit app are `model_folders` and `model_names`. For each model that the user would like to compare, they would specify the model location through its outputs folder absolute path and pass this to model_folders. Optionally, the user can also specify a name for the model using the model_names argument.
-
-The model_folder arguments require the ABSOLUTE paths to the model outputs folder. The lightning-pose output folder structure for a single model is typically structured as follows: `/path/to/lightning-pose/outputs/YYYY-MM-DD/HH-MM-SS`, where inside the last folder there are prediction csvs. The absolute path to the `HH-MM-SS` folder must be specified for metrics for the model to be properly outputted to the streamlit app.
-
-### Running app from the command line for train/test/val metrics
-Multiple models can be compared as follows, where the model folder for each model must be preceded by "--model_folders" and the name for each model to be displayed in the app must be preceded by "--model_names".
-```console
-foo@bar:~$ streamlit run /path/to/lightning_pose/apps/labeled_frame_diagnostics.py --
---model_folders=/absolute/path/to/model0/outputs --model_names=model0
---model_folders=/absolute/path/to/model1/outputs --model_names=model1
+Analyze predictions of one or more networks on the `train/test/val` images.
 ```
-To compare more models simply add more inputs to --model_folders and optionally a corresponding input to --model_names. 
+streamlit run labeled_frame_diagnostics.py -- --model_dir <ABOLUTE_PATH_TO_HYDRA_OUTPUTS_DIRECTORY>
+```
+The only argument needed is `--model_dir`, which tells the app where to find models and their predictions. `<HYDRA_OUTPUTS_DIRECTORY>` should contain hydra subfolders of the type `YYYY-MM-DD/HH-MM-SS`.
 
+(The lightning-pose output folder for a single model is typically: `/path/to/lightning-pose/outputs/YYYY-MM-DD/HH-MM-SS`, where inside the last folder there are prediction `.csv`s.)
+
+The app shows:
+    - plot of a selected metric (e.g. pixel errors, confidences) for each network and each body part, using bar/box/violin/etc plots.
+    - scatterplot of a selected metric between two networks
 
 # Video Diagnostics
-You can analyze predictions of one or multiple trained models on the video predictions outputted after training using this streamlit app.
-
-The app creates plots for:
-- time series/likelihoods of a selected keypoint (x or y coord) for each model
-- boxplot/histogram of temporal norms for each model
-- boxplot/histogram of multiview pca reprojection errors for each model
-
-### Specifying models to compare
-This operates identically to labeled_frame_diagnostics above. 
-
-### Running app from the command line for train/test/val metrics
-Multiple models can be compared as follows, where the model folder for each model must be preceded by "--model_folders" and the name for each model to be displayed in the app must be preceded by "--model_names".
-```console
-foo@bar:~$ streamlit run /path/to/lightning_pose/apps/video_diagnostics.py --
---model_folders=/absolute/path/to/model0/outputs --model_names=model0
---model_folders=/absolute/path/to/model1/outputs --model_names=model1
+Visualizes multiple networks' predictions on a test video.
 ```
-To compare more models simply add more inputs to --model_folders and optionally a corresponding input to --model_names. 
+streamlit run video_diagnostics.py -- --model_dir <ABOLUTE_PATH_TO_HYDRA_OUTPUTS_DIRECTORY>
+```
+where `--model_dir` is explained above.
+The app shows:
+- timeseries of predictions/confidences/losses of a selected keypoint (x and y coord) for each network
+- boxplot/histogram of confidences/losses for each network and each body part

--- a/lightning_pose/apps/labeled_frame_diagnostics.py
+++ b/lightning_pose/apps/labeled_frame_diagnostics.py
@@ -48,15 +48,13 @@ def run():
     # get the last two levels of each path to be presented to user
     model_folders_vis = get_model_folders_vis(model_folders)
 
-    selected_models_vis = st.sidebar.multiselect("Model folders", model_folders_vis, model_folders_vis)
+    selected_models_vis = st.sidebar.multiselect("Select models", model_folders_vis, model_folders_vis)
 
     # append this to full path
     selected_models = ["/" + os.path.join(path_example, f) for f in selected_models_vis]
     
     # search for prediction files in the selected model folders
     prediction_files = update_labeled_file_list(selected_models)
-
-    st.text(prediction_files)
 
     # col wrap when plotting results from all keypoints
     n_cols = 3

--- a/lightning_pose/apps/labeled_frame_diagnostics.py
+++ b/lightning_pose/apps/labeled_frame_diagnostics.py
@@ -19,6 +19,7 @@ import os
 
 from lightning_pose.apps.utils import build_precomputed_metrics_df, get_df_box, get_df_scatter
 from lightning_pose.apps.utils import update_labeled_file_list
+from lightning_pose.apps.utils import get_model_folders, get_path_example, get_model_folders_vis 
 from lightning_pose.apps.plots import make_seaborn_catplot, make_plotly_scatterplot, get_y_label
 from lightning_pose.apps.plots import make_plotly_catplot
 
@@ -27,7 +28,6 @@ catplot_options = ["box", "violin", "strip"]  # for plotly
 scale_options = ["linear", "log"]
 
 st.set_page_config(layout="wide")
-
 
 def run():
 
@@ -39,25 +39,18 @@ def run():
 
     # add a multiselect that shows existing model folders, and allows the user to de-select models
     # assume we have args.model_dir and we search two levels down for model folders
-    # list a all subfolders in model_dir, going three levels down. just folders not files
-    model_folders = []
-    for root, dirs, files in os.walk(args.model_dir):
-        if root.count(os.sep) - args.model_dir.count(os.sep) == 2:
-            model_folders.append(root)
+    model_folders = get_model_folders(args.model_dir)
     
     # get everything but the last two levels of the path for one example folder
     # we need this to construct the full path to the model folders, without showing all to users
-    path_example = model_folders[0]
-    path_example = path_example.split('/')[:-2]
-    path_example = os.path.join(*path_example)
+    path_example = get_path_example(model_folders)
     
-    # just to get the last two levels of the path
-    fs = []
-    for f in model_folders:
-        fs.append(f.split('/')[-2:])
-    model_folders_vis = [os.path.join(*f) for f in fs]
+    # get the last two levels of each path to be presented to user
+    model_folders_vis = get_model_folders_vis(model_folders)
+
     selected_models_vis = st.sidebar.multiselect("Model folders", model_folders_vis, model_folders_vis)
 
+    # append this to full path
     selected_models = ["/" + os.path.join(path_example, f) for f in selected_models_vis]
     
     # search for prediction files in the selected model folders

--- a/lightning_pose/apps/labeled_frame_diagnostics.py
+++ b/lightning_pose/apps/labeled_frame_diagnostics.py
@@ -19,7 +19,7 @@ import os
 
 from lightning_pose.apps.utils import build_precomputed_metrics_df, get_df_box, get_df_scatter
 from lightning_pose.apps.utils import update_labeled_file_list
-from lightning_pose.apps.utils import get_model_folders, get_path_example, get_model_folders_vis 
+from lightning_pose.apps.utils import get_model_folders, get_model_folders_vis 
 from lightning_pose.apps.plots import make_seaborn_catplot, make_plotly_scatterplot, get_y_label
 from lightning_pose.apps.plots import make_plotly_catplot
 
@@ -35,15 +35,15 @@ def run():
 
     st.title("Labeled Frame Diagnostics")
 
+    # check if args.model_dir is a dir, if not, raise an error
+    if not os.path.isdir(args.model_dir):
+        st.text(f"--model_dir {args.model_dir} does not exist. \nPlease check the path and try again.")
+
     st.sidebar.header("Data Settings")
 
     # add a multiselect that shows existing model folders, and allows the user to de-select models
     # assume we have args.model_dir and we search two levels down for model folders
     model_folders = get_model_folders(args.model_dir)
-    
-    # get everything but the last two levels of the path for one example folder
-    # we need this to construct the full path to the model folders, without showing all to users
-    path_example = get_path_example(model_folders)
     
     # get the last two levels of each path to be presented to user
     model_folders_vis = get_model_folders_vis(model_folders)
@@ -51,7 +51,7 @@ def run():
     selected_models_vis = st.sidebar.multiselect("Select models", model_folders_vis, model_folders_vis)
 
     # append this to full path
-    selected_models = ["/" + os.path.join(path_example, f) for f in selected_models_vis]
+    selected_models = ["/" + os.path.join(args.model_dir, f) for f in selected_models_vis]
     
     # search for prediction files in the selected model folders
     prediction_files = update_labeled_file_list(selected_models)
@@ -152,7 +152,7 @@ def run():
 
             # filter data
             df_metrics_filt = df_metrics[metric_to_plot][df_metrics[metric_to_plot].set == data_type]
-            n_frames_per_dtype = df_metrics_filt.shape[0] // len(selected_models) # len(args.model_folders)
+            n_frames_per_dtype = df_metrics_filt.shape[0] // len(selected_models)
 
             # plot data
             title = '%s (%i %s frames)' % (keypoint_to_plot, n_frames_per_dtype, data_type)
@@ -252,6 +252,6 @@ def run():
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--model_dir', type=str, default="/home/zeus/content/Pose-app/data/demo/models")
+    parser.add_argument('--model_dir', type=str, default=[])
 
     run()

--- a/lightning_pose/apps/utils.py
+++ b/lightning_pose/apps/utils.py
@@ -191,3 +191,28 @@ def compute_confidence(
         df_["img_file"] = df.index
 
     return df_
+
+#------------ utils related to model finding in dir ---------
+# write a function that finds all model folders in the model_dir
+def get_model_folders(model_dir):
+    model_folders = []
+    for root, dirs, files in os.walk(model_dir):
+        if root.count(os.sep) - model_dir.count(os.sep) == 2:
+            model_folders.append(root)
+    return model_folders
+
+# get everything but the last two levels of the path for one example folder
+# we need this to construct the full path to the model folders, without showing all to users
+def get_path_example(model_folders):
+    path_example = model_folders[0]
+    path_example = path_example.split('/')[:-2]
+    path_example = os.path.join(*path_example)
+    return path_example
+
+# just to get the last two levels of the path
+def get_model_folders_vis(model_folders):
+    fs = []
+    for f in model_folders:
+        fs.append(f.split('/')[-2:])
+    model_folders_vis = [os.path.join(*f) for f in fs]
+    return model_folders_vis

--- a/lightning_pose/apps/utils.py
+++ b/lightning_pose/apps/utils.py
@@ -201,14 +201,6 @@ def get_model_folders(model_dir):
             model_folders.append(root)
     return model_folders
 
-# get everything but the last two levels of the path for one example folder
-# we need this to construct the full path to the model folders, without showing all to users
-def get_path_example(model_folders):
-    path_example = model_folders[0]
-    path_example = path_example.split('/')[:-2]
-    path_example = os.path.join(*path_example)
-    return path_example
-
 # just to get the last two levels of the path
 def get_model_folders_vis(model_folders):
     fs = []

--- a/lightning_pose/apps/video_diagnostics.py
+++ b/lightning_pose/apps/video_diagnostics.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 
 from lightning_pose.apps.utils import build_precomputed_metrics_df, get_col_names, concat_dfs
 from lightning_pose.apps.utils import update_vid_metric_files_list, get_all_videos
-from lightning_pose.apps.utils import get_model_folders, get_path_example, get_model_folders_vis
+from lightning_pose.apps.utils import get_model_folders, get_model_folders_vis
 from lightning_pose.apps.plots import get_y_label
 from lightning_pose.apps.plots import make_seaborn_catplot, make_plotly_catplot, plot_precomputed_traces
 
@@ -31,14 +31,14 @@ def run():
 
     st.title("Video Diagnostics")
 
+    # check if args.model_dir is a dir, if not, raise an error
+    if not os.path.isdir(args.model_dir):
+        st.text(f"--model_dir {args.model_dir} does not exist. \nPlease check the path and try again.")
+
     st.sidebar.header("Data Settings")
 
     # ----- selecting which models to use -----
     model_folders = get_model_folders(args.model_dir)
-    
-    # get everything but the last two levels of the path for one example folder
-    # we need this to construct the full path to the model folders, without showing all to users
-    path_example = get_path_example(model_folders)
     
     # get the last two levels of each path to be presented to user
     model_folders_vis = get_model_folders_vis(model_folders)
@@ -46,7 +46,7 @@ def run():
     selected_models_vis = st.sidebar.multiselect("Select models", model_folders_vis, model_folders_vis)
 
     # append this to full path
-    selected_models = ["/" + os.path.join(path_example, f) for f in selected_models_vis]
+    selected_models = ["/" + os.path.join(args.model_dir, f) for f in selected_models_vis]
     
     # ----- selecting videos to analyze -----
     all_videos_: list = get_all_videos(selected_models)


### PR DESCRIPTION
introduced model selection in apps -- both labeled frames and video diagnostics.

changes include
1. a single CLI arg `args.model_dir` for both apps
2. fixes in apps to eliminate `args.model_folders` and  `args.model_names`
3. re-writing the docs for apps (trimmed a lot of repeating text)