### PR TITLE
update code to use original image and video pixel coordinates for all predictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ outputs/
 multirun/
 preds/
 scripts/.ipynb_checkpoints
+data/Chickadee
+tb_logs
 #scripts/configs_*
 
 # Byte-compiled / optimized / DLL files

--- a/lightning_pose/data/augmentations.py
+++ b/lightning_pose/data/augmentations.py
@@ -97,11 +97,12 @@ def imgaug_transform(cfg: DictConfig) -> iaa.Sequential:
     else:
         raise NotImplementedError("must choose imgaug kind from 'default', 'dlc', 'dlc-top-down'")
 
-    # always apply resizing transform
-    data_transform.append(
-        iaa.Resize({
-            "height": cfg.data.image_resize_dims.height,
-            "width": cfg.data.image_resize_dims.width}
-        ))
+    # do not resize when using dynamic crop pipeline
+    if not cfg.data.get('dynamic_crop', False):
+        data_transform.append(
+            iaa.Resize({
+                "height": cfg.data.image_resize_dims.height,
+                "width": cfg.data.image_resize_dims.width}
+            ))
 
     return iaa.Sequential(data_transform)

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -158,9 +158,9 @@ class LitDaliWrapper(DALIGenericIterator):
         # shape (1,) or (2, 3)
         transforms = batch[0]["transforms"][0]
         # get frame size, order is batch,seq_len,H,W,C
-        height = batch[0]["frame_size"][0,1]
-        width = batch[0]["frame_size"][0,2]
-        bbox = torch.tensor([0,0,height,width]).repeat((frames.shape[0],1))
+        height = batch[0]["frame_size"][0, 1]
+        width = batch[0]["frame_size"][0, 2]
+        bbox = torch.tensor([0, 0, height, width]).repeat((frames.shape[0], 1))
 
         return UnlabeledBatchDict(frames=frames, transforms=transforms, bbox=bbox)
 

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -63,6 +63,7 @@ def video_pipe(
     Returns:
         pipeline object to be fed to DALIGenericIterator
         data augmentation matrix (returned so that geometric transforms can be undone)
+        size of video frames, used for bbox
 
     """
     video = fn.readers.video(
@@ -80,6 +81,7 @@ def video_pipe(
         pad_last_batch=pad_last_batch,  # Important for context loaders
         file_list_include_preceding_frame=True,  # to get rid of dali warnings
     )
+    orig_size = fn.shapes(video)
     if resize_dims:
         video = fn.resize(video, size=resize_dims)
     if imgaug == "dlc" or imgaug == "dlc-top-down":
@@ -115,7 +117,7 @@ def video_pipe(
         mean=normalization_mean,
         std=normalization_std,
     )
-    return transform, matrix
+    return transform, matrix, orig_size
 
 
 class LitDaliWrapper(DALIGenericIterator):
@@ -155,8 +157,12 @@ class LitDaliWrapper(DALIGenericIterator):
         frames = batch[0]["frames"][0, :, :, :, :]
         # shape (1,) or (2, 3)
         transforms = batch[0]["transforms"][0]
+        # get frame size, order is batch,seq_len,H,W,C
+        height = batch[0]["frame_size"][0,1]
+        width = batch[0]["frame_size"][0,2]
+        bbox = torch.tensor([0,0,height,width]).repeat((frames.shape[0],1))
 
-        return UnlabeledBatchDict(frames=frames, transforms=transforms)
+        return UnlabeledBatchDict(frames=frames, transforms=transforms, bbox=bbox)
 
     def __next__(self) -> UnlabeledBatchDict:
         batch = super().__next__()
@@ -340,7 +346,7 @@ class PrepareDALI(object):
             "num_iters": self.num_iters,
             "eval_mode": "train",
             "do_context": False,
-            "output_map": ["frames", "transforms"],
+            "output_map": ["frames", "transforms", "frame_size"],
             "last_batch_policy": LastBatchPolicy.PARTIAL,
             "auto_reset": True,
         }
@@ -348,7 +354,7 @@ class PrepareDALI(object):
             "num_iters": self.num_iters,
             "eval_mode": "predict",
             "do_context": False,
-            "output_map": ["frames", "transforms"],
+            "output_map": ["frames", "transforms", "frame_size"],
             "last_batch_policy": LastBatchPolicy.FILL,
             "last_batch_padded": False,
             "auto_reset": False,
@@ -360,7 +366,7 @@ class PrepareDALI(object):
             "num_iters": self.num_iters,
             "eval_mode": "train",
             "do_context": True,
-            "output_map": ["frames", "transforms"],
+            "output_map": ["frames", "transforms", "frame_size"],
             "last_batch_policy": LastBatchPolicy.PARTIAL,
             "auto_reset": True,
         }  # taken from datamodules.py. only difference is that we need to do context
@@ -368,7 +374,7 @@ class PrepareDALI(object):
             "num_iters": self.num_iters,
             "eval_mode": "predict",
             "do_context": True,
-            "output_map": ["frames", "transforms"],
+            "output_map": ["frames", "transforms", "frame_size"],
             "last_batch_policy": LastBatchPolicy.FILL,  # LastBatchPolicy.PARTIAL,
             "last_batch_padded": False,
             "auto_reset": False,

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -200,11 +200,14 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             transformed_images = image_frames_tensor
 
         assert transformed_keypoints.shape == (self.num_targets,)
+        img_height = transformed_images.shape[1]
+        img_width = transformed_images.shape[2]
 
         return BaseLabeledExampleDict(
             images=transformed_images,  # shape (3, img_height, img_width) or (5, 3, H, W)
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
+            bbox=[0,0,img_height,img_width] # x,y,h,w of bounding box
         )
 
 

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -200,8 +200,8 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             transformed_images = image_frames_tensor
 
         assert transformed_keypoints.shape == (self.num_targets,)
-        img_height = transformed_images.shape[1]
-        img_width = transformed_images.shape[2]
+        img_height = transformed_images.shape[-2]
+        img_width = transformed_images.shape[-1]
 
         return BaseLabeledExampleDict(
             images=transformed_images,  # shape (3, img_height, img_width) or (5, 3, H, W)

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -207,7 +207,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             images=transformed_images,  # shape (3, img_height, img_width) or (5, 3, H, W)
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
-            bbox=torch.tensor([0,0,img_height,img_width]) # x,y,h,w of bounding box
+            bbox=torch.tensor([0, 0, img_height, img_width])  # x,y,h,w of bounding box
         )
 
 

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -380,9 +380,9 @@ class DetectorDataset(BaseTrackingDataset):
         }))
 
         # average finescale keypoints together to get coarsescale keypoints
-        coarse_kpts = torch.zeros((self.keypoints.shape[0],len(keypoints_for_crop),2))
-        for i,k in enumerate(keypoints_for_crop):
-            coarse_kpts[:,i,:] = self.keypoints[:,k,:].mean(dim=1)
+        coarse_kpts = torch.zeros((self.keypoints.shape[0], len(keypoints_for_crop), 2))
+        for i, k in enumerate(keypoints_for_crop):
+            coarse_kpts[:, i, :] = self.keypoints[:, k, :].mean(dim=1)
         self.keypoints = coarse_kpts
 
         if self.height % 128 != 0 or self.height % 128 != 0:
@@ -476,7 +476,7 @@ class DetectorDataset(BaseTrackingDataset):
             images=transformed_images,  # shape (3, img_height, img_width)
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
-            bbox=torch.tensor([0, 0, image.height, image.width]) # x,y,h,w of bounding box
+            bbox=torch.tensor([0, 0, image.height, image.width])  # x,y,h,w of bounding box
         )
         example_dict["heatmaps"] = self.compute_heatmap(example_dict)
         return example_dict

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -1,7 +1,7 @@
 """Dataset objects store images, labels, and functions for manipulation."""
 
 import os
-from typing import Callable, List, Literal, Optional
+from typing import Callable, List, Literal, Optional, Tuple
 
 import imgaug.augmenters as iaa
 import numpy as np
@@ -200,14 +200,12 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             transformed_images = image_frames_tensor
 
         assert transformed_keypoints.shape == (self.num_targets,)
-        img_height = transformed_images.shape[-2]
-        img_width = transformed_images.shape[-1]
 
         return BaseLabeledExampleDict(
             images=transformed_images,  # shape (3, img_height, img_width) or (5, 3, H, W)
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
-            bbox=torch.tensor([0, 0, img_height, img_width])  # x,y,h,w of bounding box
+            bbox=torch.tensor([0, 0, image.height, image.width])  # x,y,h,w of bounding box
         )
 
 
@@ -264,6 +262,7 @@ class HeatmapDataset(BaseTrackingDataset):
         self.num_targets = torch.numel(self.keypoints[0])
         self.num_keypoints = self.num_targets // 2
         self.label_heatmaps = None  # populated by `self.compute_heatmaps()`
+        print('Computing Heatmaps')
         self.compute_heatmaps()
 
     @property
@@ -337,4 +336,155 @@ class HeatmapDataset(BaseTrackingDataset):
         else:
             # we have a random augmentation; need to recompute heatmaps
             example_dict["heatmaps"] = self.compute_heatmap(example_dict)
+        return example_dict
+
+
+class DetectorDataset(BaseTrackingDataset):
+    """Heatmap dataset that contains the images and keypoints in 2D arrays."""
+
+    def __init__(
+        self,
+        root_directory: str,
+        csv_path: str,
+        resized_dims: Tuple,
+        keypoints_for_crop: List,
+        header_rows: Optional[List[int]] = [0, 1, 2],
+        imgaug_transform: Optional[Callable] = None,
+        downsample_factor: Literal[1, 2, 3] = 2,
+        do_context: bool = False,
+        uniform_heatmaps: bool = False,
+    ) -> None:
+        """Initialize the Heatmap Dataset.
+
+        Args:
+            root_directory: path to data directory
+            csv_path: path to CSV or h5 file  (within root_directory). CSV file
+                should be in the form
+                (image_path, bodypart_1_x, bodypart_1_y, ..., bodypart_n_y)
+                Note: image_path is relative to the given root_directory
+            header_rows: which rows in the csv are header rows
+            imgaug_transform: imgaug transform pipeline to apply to images
+            downsample_factor: factor by which to downsample original image dims to have a smaller
+                heatmap
+            do_context: include additional frames of context if possible
+
+        """
+        super().__init__(
+            root_directory=root_directory,
+            csv_path=csv_path,
+            header_rows=header_rows,
+            imgaug_transform=imgaug_transform,
+            do_context=do_context,
+        )
+        self.resized_dims = resized_dims
+        self.downsample_factor = downsample_factor
+        self.output_sigma = 1.25  # should be sigma/2 ^downsample factor
+        self.uniform_heatmaps = uniform_heatmaps
+        self.keypoints_for_crop = keypoints_for_crop
+
+        # add a resize operation to end of image augmentation pipeline
+        self.imgaug_transform.append(iaa.Resize({
+            "height": self.height, "width": self.width
+        }))
+
+        # average finescale keypoints together to get coarsescale keypoints
+        coarse_kpts = torch.zeros((self.keypoints.shape[0],len(keypoints_for_crop),2))
+        for i,k in enumerate(keypoints_for_crop):
+            coarse_kpts[:,i,:] = self.keypoints[:,k,:].mean(dim=1)
+        self.keypoints = coarse_kpts
+
+        if self.height % 128 != 0 or self.height % 128 != 0:
+            print(
+                "image dimensions (after transformation) must be repeatably "
+                + "divisible by 2!"
+            )
+            print("current image dimensions after transformation are:")
+            exit()
+
+        # Compute heatmaps as preprocessing step
+        self.num_targets = torch.numel(self.keypoints[0])
+        self.num_keypoints = self.num_targets // 2
+        # self.label_heatmaps = None  # populated by `self.compute_heatmaps()`
+        # print('Computing Heatmaps')
+        # self.compute_heatmaps()
+
+    @property
+    def height(self) -> int:
+        # assume resizing transformation is the last imgaug one
+        return self.resized_dims[1]
+
+    @property
+    def width(self) -> int:
+        # assume resizing transformation is the last imgaug one
+        return self.resized_dims[0]
+
+    @property
+    def output_shape(self) -> tuple:
+        return (
+            self.height // 2**self.downsample_factor,
+            self.width // 2**self.downsample_factor,
+        )
+
+    def compute_heatmap(
+            self, example_dict: BaseLabeledExampleDict
+    ) -> TensorType["num_keypoints", "heatmap_height", "heatmap_width"]:
+        """Compute 2D heatmaps from arbitrary (x, y) coordinates."""
+
+        # reshape
+        keypoints = example_dict["keypoints"].reshape(self.num_keypoints, 2)
+
+        # introduce new nans where data augmentation has moved the keypoint out of the original
+        # frame
+        new_nans = torch.logical_or(
+            torch.lt(keypoints[:, 0], torch.tensor(0)),
+            torch.lt(keypoints[:, 1], torch.tensor(0)),
+        )
+        new_nans = torch.logical_or(
+            new_nans, torch.ge(keypoints[:, 0], torch.tensor(self.width))
+        )
+        new_nans = torch.logical_or(
+            new_nans, torch.ge(keypoints[:, 1], torch.tensor(self.height))
+        )
+        keypoints[new_nans, :] = torch.nan
+
+        y_heatmap = generate_heatmaps(
+            keypoints=keypoints.unsqueeze(0),  # add batch dim
+            height=self.height,
+            width=self.width,
+            output_shape=self.output_shape,
+            sigma=self.output_sigma,
+            uniform_heatmaps=self.uniform_heatmaps,
+        )
+
+        return y_heatmap[0]
+
+    def __getitem__(self, idx: int) -> HeatmapLabeledExampleDict:
+        img_name = self.image_names[idx]
+        keypoints_on_image = self.keypoints[idx]
+
+        # read image from file and apply transformations (if any)
+        file_name = os.path.join(self.root_directory, img_name)
+        # if 1 color channel, change to 3.
+        image = Image.open(file_name).convert("RGB")
+        if self.imgaug_transform is not None:
+            transformed_images, transformed_keypoints = self.imgaug_transform(
+                images=np.expand_dims(image, axis=0),
+                keypoints=np.expand_dims(keypoints_on_image, axis=0),
+            )  # expands add batch dim for imgaug
+            # get rid of the batch dim
+            transformed_images = transformed_images[0]
+            transformed_keypoints = transformed_keypoints[0].reshape(-1)
+        else:
+            transformed_images = np.expand_dims(image, axis=0)
+            transformed_keypoints = np.expand_dims(keypoints_on_image, axis=0)
+
+        transformed_images = self.pytorch_transform(transformed_images)
+        assert transformed_keypoints.shape == (self.num_targets,)
+        example_dict = BaseLabeledExampleDict(
+            images=transformed_images,  # shape (3, img_height, img_width)
+            keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
+            idxs=idx,
+            bbox=torch.tensor([0, 0, image.height, image.width]) # x,y,h,w of bounding box
+        )
+        example_dict["heatmaps"] = self.compute_heatmap(example_dict)
         return example_dict

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -207,7 +207,7 @@ class BaseTrackingDataset(torch.utils.data.Dataset):
             images=transformed_images,  # shape (3, img_height, img_width) or (5, 3, H, W)
             keypoints=torch.from_numpy(transformed_keypoints),  # shape (n_targets,)
             idxs=idx,
-            bbox=[0,0,img_height,img_width] # x,y,h,w of bounding box
+            bbox=torch.tensor([0,0,img_height,img_width]) # x,y,h,w of bounding box
         )
 
 

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -261,9 +261,6 @@ class HeatmapDataset(BaseTrackingDataset):
         # Compute heatmaps as preprocessing step
         self.num_targets = torch.numel(self.keypoints[0])
         self.num_keypoints = self.num_targets // 2
-        self.label_heatmaps = None  # populated by `self.compute_heatmaps()`
-        print('Computing Heatmaps')
-        self.compute_heatmaps()
 
     @property
     def output_shape(self) -> tuple:
@@ -330,12 +327,7 @@ class HeatmapDataset(BaseTrackingDataset):
 
         """
         example_dict: BaseLabeledExampleDict = super().__getitem__(idx)
-        if len(self.imgaug_transform) == 1 and isinstance(self.imgaug_transform[0], iaa.Resize):
-            # we have a deterministic resizing augmentation; use precomputed heatmaps
-            example_dict["heatmaps"] = self.label_heatmaps[idx]
-        else:
-            # we have a random augmentation; need to recompute heatmaps
-            example_dict["heatmaps"] = self.compute_heatmap(example_dict)
+        example_dict["heatmaps"] = self.compute_heatmap(example_dict)
         return example_dict
 
 

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -23,6 +23,7 @@ class BaseLabeledExampleDict(TypedDict):
     idxs: int
     bbox: TensorType["xyhw":4, float]
 
+
 class DynamicLabeledExampleDict(BaseLabeledExampleDict):
     """Return type when calling __getitem__() on DynamicDataset."""
 
@@ -51,7 +52,7 @@ class BaseLabeledBatchDict(TypedDict):
 class DynamicLabeledBatchDict(BaseLabeledBatchDict):
     """Batch type for dynamic labeled data"""
 
-    keypoints: List[List[TensorType["num_targets", float]]] # list over batch then over instances
+    keypoints: List[List[TensorType["num_targets", float]]]  # list over batch then over instances
     bbox: List[List[TensorType["xyhw":4, float]]]
 
 

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -23,7 +23,6 @@ class BaseLabeledExampleDict(TypedDict):
     idxs: int
     bbox: TensorType["xyhw":4, float]
 
-
 class DynamicLabeledExampleDict(BaseLabeledExampleDict):
     """Return type when calling __getitem__() on DynamicDataset."""
 
@@ -76,6 +75,7 @@ class UnlabeledBatchDict(TypedDict):
         TensorType["null":1, float],
         torch.Tensor,
     ]
+    bbox: TensorType["seq_len", "xyhw":4, float]
     # transforms shapes
     # (seq_len, 2, 3): different transform for each sequence
     # (2, 3): same transform for all returned frames/keypoints

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -21,6 +21,7 @@ class BaseLabeledExampleDict(TypedDict):
     ]
     keypoints: TensorType["num_targets", float]
     idxs: int
+    bbox: TensorType["xyhw":4, float]
 
 
 class HeatmapLabeledExampleDict(BaseLabeledExampleDict):
@@ -38,6 +39,7 @@ class BaseLabeledBatchDict(TypedDict):
     ]
     keypoints: TensorType["batch", "num_targets", float]
     idxs: TensorType["batch", int]
+    bbox: TensorType["batch", "xyhw":4, float]
 
 
 class HeatmapLabeledBatchDict(BaseLabeledBatchDict):

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -24,6 +24,13 @@ class BaseLabeledExampleDict(TypedDict):
     bbox: TensorType["xyhw":4, float]
 
 
+class DynamicLabeledExampleDict(BaseLabeledExampleDict):
+    """Return type when calling __getitem__() on DynamicDataset."""
+
+    keypoints: List[TensorType["num_targets", float]]
+    bbox: List[TensorType["xyhw":4, float]]
+
+
 class HeatmapLabeledExampleDict(BaseLabeledExampleDict):
     """Return type when calling __getitem__() on HeatmapTrackingDataset."""
 
@@ -40,6 +47,13 @@ class BaseLabeledBatchDict(TypedDict):
     keypoints: TensorType["batch", "num_targets", float]
     idxs: TensorType["batch", int]
     bbox: TensorType["batch", "xyhw":4, float]
+
+
+class DynamicLabeledBatchDict(BaseLabeledBatchDict):
+    """Batch type for dynamic labeled data"""
+
+    keypoints: List[List[TensorType["num_targets", float]]] # list over batch then over instances
+    bbox: List[List[TensorType["xyhw":4, float]]]
 
 
 class HeatmapLabeledBatchDict(BaseLabeledBatchDict):

--- a/lightning_pose/models/heatmap_tracker.py
+++ b/lightning_pose/models/heatmap_tracker.py
@@ -269,13 +269,14 @@ class HeatmapTracker(BaseSupervisedTracker):
         # softmax temp stays 1 here; to modify for model predictions, see constructor
         return spatial_softmax2d(heatmaps, temperature=torch.tensor([1.0]))
 
-    def convert_bbox_coords(self, batch_dict: HeatmapLabeledBatchDict, predicted_keypoints: TensorType["batch", "num_targets"]
+    def convert_bbox_coords(self, batch_dict: HeatmapLabeledBatchDict,
+                            predicted_keypoints: TensorType["batch", "num_targets"]
                             ) -> TensorType["batch", "num_targets"]:
         # reshape from (batch, nTargets) back to (batch, nKey, 2), in x,y order
         predicted_keypoints = predicted_keypoints.reshape((-1, self.num_keypoints, 2))
         # divide by image dims to get 0-1 normalized coordinates
-        predicted_keypoints[:, :, 0] /= batch_dict["images"].shape[-1]  # last dim is width "x"
-        predicted_keypoints[:, :, 1] /= batch_dict["images"].shape[-2]  # 2nd to last dim is height "y"
+        predicted_keypoints[:, :, 0] /= batch_dict["images"].shape[-1]  # -1 dim is width "x"
+        predicted_keypoints[:, :, 1] /= batch_dict["images"].shape[-2]  # -2 dim is height "y"
         # multiply and add by bbox dims (x,y,h,w)
         for i in range(predicted_keypoints.shape[0]):
             predicted_keypoints[i, :, 0] *= batch_dict["bbox"][i, 3]  # scale x by box width

--- a/lightning_pose/models/heatmap_tracker.py
+++ b/lightning_pose/models/heatmap_tracker.py
@@ -278,7 +278,7 @@ class HeatmapTracker(BaseSupervisedTracker):
         if "images" in batch_dict.keys():
             predicted_keypoints[:, :, 0] /= batch_dict["images"].shape[-1]  # -1 dim is width "x"
             predicted_keypoints[:, :, 1] /= batch_dict["images"].shape[-2]  # -2 dim is height "y"
-        else: # we have unlabeled dict, 'frames' instead of 'images'
+        else:  # we have unlabeled dict, 'frames' instead of 'images'
             predicted_keypoints[:, :, 0] /= batch_dict["frames"].shape[-1]  # -1 dim is width "x"
             predicted_keypoints[:, :, 1] /= batch_dict["frames"].shape[-2]  # -2 dim is height "y"
         # multiply and add by bbox dims (x,y,h,w)

--- a/lightning_pose/models/heatmap_tracker.py
+++ b/lightning_pose/models/heatmap_tracker.py
@@ -332,6 +332,8 @@ class HeatmapTracker(BaseSupervisedTracker):
         # TODO: extend this to unlabeled data
         if "images" in batch_dict.keys():
             predicted_keypoints = self.convert_bbox_coords(batch_dict, predicted_keypoints)
+        else:
+            print('TO DO: convert bbox coords for unlabeled frames')
         if return_heatmaps:
             return predicted_keypoints, confidence, predicted_heatmaps
         else:

--- a/lightning_pose/models/heatmap_tracker.py
+++ b/lightning_pose/models/heatmap_tracker.py
@@ -294,10 +294,11 @@ class HeatmapTracker(BaseSupervisedTracker):
         predicted_keypoints, confidence = self.run_subpixelmaxima(predicted_heatmaps)
         # bounding box coords -> original image coords
         predicted_keypoints = self.convert_bbox_coords(batch_dict, predicted_keypoints)
+        target_keypoints = self.convert_bbox_coords(batch_dict, batch_dict["keypoints"])
         return {
             "heatmaps_targ": batch_dict["heatmaps"],
             "heatmaps_pred": predicted_heatmaps,
-            "keypoints_targ": batch_dict["keypoints"],
+            "keypoints_targ": target_keypoints,
             "keypoints_pred": predicted_keypoints,
             "confidences": confidence,
         }

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -202,13 +202,13 @@ class PredictionHandler:
         predictions = np.zeros((keypoints_np.shape[0], num_joints * 3))
         predictions[:, 0] = np.arange(keypoints_np.shape[0])
         # put x vals back in original pixel space
-        x_resize = self.cfg.data.image_resize_dims.width
-        x_og = self.cfg.data.image_orig_dims.width
-        predictions[:, 0::3] = keypoints_np[:, 0::2] / x_resize * x_og
+        # x_resize = self.cfg.data.image_resize_dims.width
+        # x_og = self.cfg.data.image_orig_dims.width
+        predictions[:, 0::3] = keypoints_np[:, 0::2] #/ x_resize * x_og
         # put y vals back in original pixel space
-        y_resize = self.cfg.data.image_resize_dims.height
-        y_og = self.cfg.data.image_orig_dims.height
-        predictions[:, 1::3] = keypoints_np[:, 1::2] / y_resize * y_og
+        # y_resize = self.cfg.data.image_resize_dims.height
+        # y_og = self.cfg.data.image_orig_dims.height
+        predictions[:, 1::3] = keypoints_np[:, 1::2] #/ y_resize * y_og
         predictions[:, 2::3] = confidence_np
 
         return predictions

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -201,8 +201,8 @@ class PredictionHandler:
         num_joints = confidence_np.shape[-1]  # model.num_keypoints
         predictions = np.zeros((keypoints_np.shape[0], num_joints * 3))
         predictions[:, 0] = np.arange(keypoints_np.shape[0])
-        predictions[:, 0::3] = keypoints_np[:, 0::2] #/ x_resize * x_og
-        predictions[:, 1::3] = keypoints_np[:, 1::2] #/ y_resize * y_og
+        predictions[:, 0::3] = keypoints_np[:, 0::2]
+        predictions[:, 1::3] = keypoints_np[:, 1::2]
         predictions[:, 2::3] = confidence_np
 
         return predictions

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -201,13 +201,7 @@ class PredictionHandler:
         num_joints = confidence_np.shape[-1]  # model.num_keypoints
         predictions = np.zeros((keypoints_np.shape[0], num_joints * 3))
         predictions[:, 0] = np.arange(keypoints_np.shape[0])
-        # put x vals back in original pixel space
-        # x_resize = self.cfg.data.image_resize_dims.width
-        # x_og = self.cfg.data.image_orig_dims.width
         predictions[:, 0::3] = keypoints_np[:, 0::2] #/ x_resize * x_og
-        # put y vals back in original pixel space
-        # y_resize = self.cfg.data.image_resize_dims.height
-        # y_og = self.cfg.data.image_orig_dims.height
         predictions[:, 1::3] = keypoints_np[:, 1::2] #/ y_resize * y_og
         predictions[:, 2::3] = confidence_np
 

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -607,7 +607,7 @@ def get_detector_model(cfg: DictConfig, data_dir: str, video_dir: Optional[str] 
         if key in detector_cfg.data:
             detector_cfg.data[key] = detector_cfg.data.detector[key]
     for key in detector_cfg.model.detector:
-        if key in detector_cfg.data:
+        if key in detector_cfg.model:
             detector_cfg.model[key] = detector_cfg.model.detector[key]
 
     # detector model gets full images in, should use standard image resizing pipeline

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -86,14 +86,14 @@ def get_dataset(
     else:
         raise NotImplementedError("%s is an invalid cfg.model.model_type" % cfg.model.model_type)
 
-    image = Image.open(os.path.join(dataset.root_directory, dataset.image_names[0])).convert("RGB")
-    if image.size != (cfg.data.image_orig_dims.width, cfg.data.image_orig_dims.height):
-        raise ValueError(
-            f"image_orig_dims in data configuration file is "
-            f"(width={cfg.data.image_orig_dims.width}, height={cfg.data.image_orig_dims.height}) "
-            f"but your image size is (width={image.size[0]}, height={image.size[1]}). "
-            f"Please update the data configuration file"
-        )
+    # image = Image.open(os.path.join(dataset.root_directory, dataset.image_names[0])).convert("RGB")
+    # if image.size != (cfg.data.image_orig_dims.width, cfg.data.image_orig_dims.height):
+    #     raise ValueError(
+    #         f"image_orig_dims in data configuration file is "
+    #         f"(width={cfg.data.image_orig_dims.width}, height={cfg.data.image_orig_dims.height}) "
+    #         f"but your image size is (width={image.size[0]}, height={image.size[1]}). "
+    #         f"Please update the data configuration file"
+    #     )
 
     return dataset
 
@@ -205,7 +205,7 @@ def get_loss_factories(
             elif loss_name == "pca_singleview":
                 loss_params_dict["unsupervised"][loss_name][
                     "columns_for_singleview_pca"
-                ] = cfg.data.columns_for_singleview_pca
+                ] = cfg.data.get('columns_for_singleview_pca', None)
 
     # build supervised loss factory, which orchestrates all supervised losses
     loss_factory_sup = LossFactory(

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -86,15 +86,6 @@ def get_dataset(
     else:
         raise NotImplementedError("%s is an invalid cfg.model.model_type" % cfg.model.model_type)
 
-    # image = Image.open(os.path.join(dataset.root_directory, dataset.image_names[0])).convert("RGB")
-    # if image.size != (cfg.data.image_orig_dims.width, cfg.data.image_orig_dims.height):
-    #     raise ValueError(
-    #         f"image_orig_dims in data configuration file is "
-    #         f"(width={cfg.data.image_orig_dims.width}, height={cfg.data.image_orig_dims.height}) "
-    #         f"but your image size is (width={image.size[0]}, height={image.size[1]}). "
-    #         f"Please update the data configuration file"
-    #     )
-
     return dataset
 
 

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -559,8 +559,6 @@ def export_predictions_and_labeled_video(
     # update video size in config
     video_clip = VideoFileClip(video_file)
     cfg_copy = copy.deepcopy(cfg)
-    cfg_copy.data.image_orig_dims.width = video_clip.w
-    cfg_copy.data.image_orig_dims.height = video_clip.h
 
     # compute predictions
     preds_df = predict_single_video(

--- a/lightning_pose/utils/scripts.py
+++ b/lightning_pose/utils/scripts.py
@@ -3,7 +3,7 @@
 import copy
 import os
 from collections import OrderedDict
-from typing import Dict, List, Optional, Union, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 import imgaug.augmenters as iaa
 import lightning.pytorch as pl
@@ -12,7 +12,6 @@ import pandas as pd
 import torch
 from moviepy.editor import VideoFileClip
 from omegaconf import DictConfig, OmegaConf
-from PIL import Image
 from typeguard import typechecked
 
 from lightning_pose.callbacks import AnnealWeight

--- a/scripts/configs/config_birdCOM.yaml
+++ b/scripts/configs/config_birdCOM.yaml
@@ -82,7 +82,7 @@ model:
   # resnet50_human_jhmdb | resnet50_human_res_rle | resnet50_human_top_res
   # efficientnet_b0 | efficientnet_b1 | efficientnet_b2
   # vit_b_sam | vit_h_sam
-  backbone: resnet50_animal_ap10k
+  backbone: efficientnet_b2
   # prediction mode: regression | heatmap | heatmap_mhcrnn (context)
   model_type: heatmap
   # which heatmap loss to use
@@ -99,7 +99,7 @@ dali:
     train:
       sequence_length: 16
     predict:
-      sequence_length: 96
+      sequence_length: 64
 
   context:
     train:

--- a/scripts/configs/config_birdCOM.yaml
+++ b/scripts/configs/config_birdCOM.yaml
@@ -1,14 +1,14 @@
 data:
   # dimensions of training images
   image_orig_dims:
-    height: null
-    width: null
+    height: 2816
+    width: 1408
   # resize dimensions to streamline model creation
   image_resize_dims:
-    height: null
-    width: null
+    height: 384
+    width: 384
   # ABSOLUTE path to data directory
-  data_dir: null
+  data_dir: data/chickadee-example
   # ABSOLUTE path to unlabeled videos' directory
   video_dir: null
   # location of labels; this should be relative to `data_dir`
@@ -16,27 +16,51 @@ data:
   # downsample heatmaps - 2 | 3
   downsample_factor: 2
   # total number of keypoints
-  num_keypoints: null
+  num_keypoints: 18
   # keypoint names
-  keypoint_names: null
-  # indicator to use 2-stage dynamic crop algorithm
-  dynamic_crop: False
+  keypoint_names:
+    - beak_top
+    - beak_bot
+    - head_top
+    - head_back
+    - belly
+    - back
+    - tail_base
+    - tail_tip
+    - eye_left
+    - bib_left
+    - shoulder_left
+    - ankle_left
+    - foot_left
+    - eye_right
+    - bib_right
+    - shoulder_right
+    - ankle_right
+    - foot_right
+  # indicator to use 2-stage dynamic crop algorithm, False/True
+  dynamic_crop: True
   # max allowed number of instances, i.e. 1 for single-animal, >1 for multiple animal
   num_max_instances: 1
   # detector network params
   detector:
     # resampled image size for detector network
     image_resize_dims:
-      height: null
-      width: null
+      height: 512
+      width: 256
     # heatmap downsample factor for detector network
     downsample_factor: 2
     # list of lists for keypoints to average and detect
-    keypoints_for_crop: null
+    keypoints_for_crop:
+      - [0,1,8,13]
+      - [4,5,10,15]
+      - [7]
     # number of coarse keypoints to track, should match outer list length of keypoints_for_crop
-    num_keypoints: null
+    num_keypoints: 3
     # names of the coarse keypoints
-    keypoint_names: null
+    keypoint_names:
+      - head
+      - body
+      - tail
   # for mirrored setups with all keypoints defined in same csv file, define matching
   # columns for different keypoints (assumes x-y-x-y interleaving)
   # each list corresponds to a single view, so in the example below there are 2 views
@@ -52,7 +76,7 @@ training:
   # default- resizing only
   # dlc- imgaug pipeline implemented in DLC 2.0 package
   # dlc-top-down- dlc augmentations plus vertical and horizontal flips
-  imgaug: dlc
+  imgaug: dlc-top-down
   # batch size of labeled data during training
   train_batch_size: 16
   # batch size of labeled data during validation

--- a/scripts/configs/config_birdCOM.yaml
+++ b/scripts/configs/config_birdCOM.yaml
@@ -1,8 +1,4 @@
 data:
-  # dimensions of training images
-  image_orig_dims:
-    height: 1696
-    width: 2816
   # resize dimensions to streamline model creation
   image_resize_dims:
     height: 384
@@ -55,9 +51,9 @@ data:
       - [4,5,10,15]
       - [7]
     # number of coarse keypoints to track, should match outer list length of keypoints_for_crop
-    num_keypoints_for_crop: 3
+    num_keypoints: 3
     # names of the coarse keypoints
-    keypoint_names_for_crop:
+    keypoint_names:
       - head
       - body
       - tail
@@ -95,11 +91,11 @@ training:
   # number of cpu workers for data loaders
   num_workers: 8
   # epochs over which to assess validation metrics for early stopping
-  early_stop_patience: 3
+  early_stop_patience: 10
   # epoch at which backbone network weights begin updating
-  unfreezing_epoch: 20
+  unfreezing_epoch: 10
   # max training epochs; training may exit before due to early stopping
-  min_epochs: 100
+  min_epochs: 50
   max_epochs: 750
   # frequency to log training metrics (one step is one batch)
   log_every_n_steps: 10
@@ -116,7 +112,7 @@ training:
   lr_scheduler: multisteplr
   lr_scheduler_params:
     multisteplr:
-      milestones: [150, 200, 250]
+      milestones: [40, 60, 80]
       gamma: 0.5
 
 model:

--- a/scripts/configs/config_birdCOM.yaml
+++ b/scripts/configs/config_birdCOM.yaml
@@ -1,71 +1,28 @@
 data:
   # resize dimensions to streamline model creation
   image_resize_dims:
-    height: 384
-    width: 384
+    height: 256
+    width: 512
   # ABSOLUTE path to data directory
-  data_dir: data/Chickadee
+  data_dir: "/home/selmaan/Documents/GitHub/lightning-pose/data/Chickadee"
   # ABSOLUTE path to unlabeled videos' directory
-  video_dir: null
+  video_dir: "/home/selmaan/Documents/GitHub/lightning-pose/data/Chickadee/videos"
   # location of labels; this should be relative to `data_dir`
-  csv_file: All_Labels.csv
+  csv_file: COM_Labels.csv
   # downsample heatmaps - 2 | 3
   downsample_factor: 2
   # total number of keypoints
-  num_keypoints: 18
+  num_keypoints: 3
   # keypoint names
   keypoint_names:
-    - beak_top
-    - beak_bot
-    - head_top
-    - head_back
-    - belly
-    - back
-    - tail_base
-    - tail_tip
-    - eye_left
-    - bib_left
-    - shoulder_left
-    - ankle_left
-    - foot_left
-    - eye_right
-    - bib_right
-    - shoulder_right
-    - ankle_right
-    - foot_right
+    - head
+    - body
+    - tail
   # indicator to use 2-stage dynamic crop algorithm, False/True
-  dynamic_crop: True
+  dynamic_crop: False
   # max allowed number of instances, i.e. 1 for single-animal, >1 for multiple animal
   num_max_instances: 1
   # detector network params
-  detector:
-    # resampled image size for detector network
-    image_resize_dims:
-      height: 256
-      width: 512
-    # heatmap downsample factor for detector network
-    downsample_factor: 2
-    # list of lists for keypoints to average and detect
-    keypoints_for_crop:
-      - [0,1,8,13]
-      - [4,5,10,15]
-      - [7]
-    # number of coarse keypoints to track, should match outer list length of keypoints_for_crop
-    num_keypoints: 3
-    # names of the coarse keypoints
-    keypoint_names:
-      - head
-      - body
-      - tail
-  # for mirrored setups with all keypoints defined in same csv file, define matching
-  # columns for different keypoints (assumes x-y-x-y interleaving)
-  # each list corresponds to a single view, so in the example below there are 2 views
-  # keypoint 0 is from view 0 and matches up with keypoint 8 from view 2
-  # columns that correspond to keypoints only labeled in a single view are omitted
-  # this info is only used for the multiview pca loss
-  mirrored_column_matches: null
-  # list of indices of keypoints used for pca singleview loss (use order of labels file)
-  columns_for_singleview_pca: null
 
 training:
   # select from one of several predefined image/video augmentation pipelines
@@ -89,13 +46,13 @@ training:
   # number of gpus to train a single model
   num_gpus: 1
   # number of cpu workers for data loaders
-  num_workers: 8
+  num_workers: 16
   # epochs over which to assess validation metrics for early stopping
   early_stop_patience: 10
   # epoch at which backbone network weights begin updating
   unfreezing_epoch: 10
   # max training epochs; training may exit before due to early stopping
-  min_epochs: 50
+  min_epochs: 100
   max_epochs: 750
   # frequency to log training metrics (one step is one batch)
   log_every_n_steps: 10
@@ -112,13 +69,13 @@ training:
   lr_scheduler: multisteplr
   lr_scheduler_params:
     multisteplr:
-      milestones: [40, 60, 80]
+      milestones: [40, 70, 100]
       gamma: 0.5
 
 model:
   # list of unsupervised losses
   # "pca_singleview" | "pca_multiview" | "temporal" | "unimodal_mse" | "unimodal_kl"
-  losses_to_use: []
+  losses_to_use: ["temporal"]
   # backbone network:
   # resnet18 | resnet34 | resnet50 | resnet101 | resnet152 | resnet50_contrastive
   # resnet50_animalpose_apose | resnet50_animal_ap10k
@@ -132,15 +89,7 @@ model:
   # mse | kl | js
   heatmap_loss_type: mse
   # directory name for model saving
-  model_name: chickadee_posture
-  # field to hold parameters for the detector network, when using dynamic-crop algorithm
-  detector:
-    # backbone to use for detector network (same options as model.backbone)
-    backbone: resnet50_animal_ap10k
-    # detector losses to use (same options as model.losses_to_use)
-    losses_to_use: []
-    # directory for detector model saving
-    model_name: chickadee_detector
+  model_name: chickadee_com
 
 dali:
   general:
@@ -148,7 +97,7 @@ dali:
 
   base:
     train:
-      sequence_length: 32
+      sequence_length: 16
     predict:
       sequence_length: 96
 

--- a/scripts/configs/config_birdCOM.yaml
+++ b/scripts/configs/config_birdCOM.yaml
@@ -1,18 +1,18 @@
 data:
   # dimensions of training images
   image_orig_dims:
-    height: 2816
-    width: 1408
+    height: 1696
+    width: 2816
   # resize dimensions to streamline model creation
   image_resize_dims:
     height: 384
     width: 384
   # ABSOLUTE path to data directory
-  data_dir: data/chickadee-example
+  data_dir: data/Chickadee
   # ABSOLUTE path to unlabeled videos' directory
   video_dir: null
   # location of labels; this should be relative to `data_dir`
-  csv_file: CollectedData.csv
+  csv_file: All_Labels.csv
   # downsample heatmaps - 2 | 3
   downsample_factor: 2
   # total number of keypoints
@@ -45,8 +45,8 @@ data:
   detector:
     # resampled image size for detector network
     image_resize_dims:
-      height: 512
-      width: 256
+      height: 256
+      width: 512
     # heatmap downsample factor for detector network
     downsample_factor: 2
     # list of lists for keypoints to average and detect
@@ -55,9 +55,9 @@ data:
       - [4,5,10,15]
       - [7]
     # number of coarse keypoints to track, should match outer list length of keypoints_for_crop
-    num_keypoints: 3
+    num_keypoints_for_crop: 3
     # names of the coarse keypoints
-    keypoint_names:
+    keypoint_names_for_crop:
       - head
       - body
       - tail
@@ -93,13 +93,13 @@ training:
   # number of gpus to train a single model
   num_gpus: 1
   # number of cpu workers for data loaders
-  num_workers: 4
+  num_workers: 8
   # epochs over which to assess validation metrics for early stopping
   early_stop_patience: 3
   # epoch at which backbone network weights begin updating
   unfreezing_epoch: 20
   # max training epochs; training may exit before due to early stopping
-  min_epochs: 300
+  min_epochs: 100
   max_epochs: 750
   # frequency to log training metrics (one step is one batch)
   log_every_n_steps: 10
@@ -136,7 +136,15 @@ model:
   # mse | kl | js
   heatmap_loss_type: mse
   # directory name for model saving
-  model_name: test
+  model_name: chickadee_posture
+  # field to hold parameters for the detector network, when using dynamic-crop algorithm
+  detector:
+    # backbone to use for detector network (same options as model.backbone)
+    backbone: resnet50_animal_ap10k
+    # detector losses to use (same options as model.losses_to_use)
+    losses_to_use: []
+    # directory for detector model saving
+    model_name: chickadee_detector
 
 dali:
   general:

--- a/scripts/configs/config_birdCOM_backup.yaml
+++ b/scripts/configs/config_birdCOM_backup.yaml
@@ -1,0 +1,265 @@
+data:
+  # resize dimensions to streamline model creation
+  image_resize_dims:
+    height: 384
+    width: 384
+  # ABSOLUTE path to data directory
+  data_dir: "/home/selmaan/Documents/GitHub/lightning-pose/data/Chickadee"
+  # ABSOLUTE path to unlabeled videos' directory
+  video_dir: "/home/selmaan/Documents/GitHub/lightning-pose/data/Chickadee/videos"
+  # location of labels; this should be relative to `data_dir`
+  csv_file: All_Labels.csv
+  # downsample heatmaps - 2 | 3
+  downsample_factor: 2
+  # total number of keypoints
+  num_keypoints: 18
+  # keypoint names
+  keypoint_names:
+    - beak_top
+    - beak_bot
+    - head_top
+    - head_back
+    - belly
+    - back
+    - tail_base
+    - tail_tip
+    - eye_left
+    - bib_left
+    - shoulder_left
+    - ankle_left
+    - foot_left
+    - eye_right
+    - bib_right
+    - shoulder_right
+    - ankle_right
+    - foot_right
+  # indicator to use 2-stage dynamic crop algorithm, False/True
+  dynamic_crop: True
+  # max allowed number of instances, i.e. 1 for single-animal, >1 for multiple animal
+  num_max_instances: 1
+  # detector network params
+  detector:
+    # resampled image size for detector network
+    image_resize_dims:
+      height: 256
+      width: 512
+    # heatmap downsample factor for detector network
+    downsample_factor: 2
+    # list of lists for keypoints to average and detect
+    keypoints_for_crop:
+      - [0,1,8,13]
+      - [4,5,10,15]
+      - [7]
+    # number of coarse keypoints to track, should match outer list length of keypoints_for_crop
+    num_keypoints: 3
+    # names of the coarse keypoints
+    keypoint_names:
+      - head
+      - body
+      - tail
+  # for mirrored setups with all keypoints defined in same csv file, define matching
+  # columns for different keypoints (assumes x-y-x-y interleaving)
+  # each list corresponds to a single view, so in the example below there are 2 views
+  # keypoint 0 is from view 0 and matches up with keypoint 8 from view 2
+  # columns that correspond to keypoints only labeled in a single view are omitted
+  # this info is only used for the multiview pca loss
+  mirrored_column_matches: null
+  # list of indices of keypoints used for pca singleview loss (use order of labels file)
+  columns_for_singleview_pca: null
+
+training:
+  # select from one of several predefined image/video augmentation pipelines
+  # default- resizing only
+  # dlc- imgaug pipeline implemented in DLC 2.0 package
+  # dlc-top-down- dlc augmentations plus vertical and horizontal flips
+  imgaug: dlc-top-down
+  # batch size of labeled data during training
+  train_batch_size: 12
+  # batch size of labeled data during validation
+  val_batch_size: 32
+  # batch size of labeled data during test
+  test_batch_size: 32
+  # fraction of labeled data used for training
+  train_prob: 0.8
+  # fraction of labeled data used for validation (remaining used for test)
+  val_prob: 0.1
+  # <=1 - fraction of total train frames (determined by `train_prob`) used for training
+  # >1 - number of total train frames used for training
+  train_frames: 1
+  # number of gpus to train a single model
+  num_gpus: 1
+  # number of cpu workers for data loaders
+  num_workers: 16
+  # epochs over which to assess validation metrics for early stopping
+  early_stop_patience: 10
+  # epoch at which backbone network weights begin updating
+  unfreezing_epoch: 10
+  # max training epochs; training may exit before due to early stopping
+  min_epochs: 50
+  max_epochs: 750
+  # frequency to log training metrics (one step is one batch)
+  log_every_n_steps: 10
+  # frequency to log validation metrics
+  check_val_every_n_epoch: 5
+  # select gpu for training
+  gpu_id: 0
+  # rng seed for labeled batches
+  rng_seed_data_pt: 0
+  # rng seed for weight initialization
+  rng_seed_model_pt: 0
+  # learning rate scheduler
+  # multisteplr | [todo - reducelronplateau]
+  lr_scheduler: multisteplr
+  lr_scheduler_params:
+    multisteplr:
+      milestones: [40, 60, 80]
+      gamma: 0.5
+
+model:
+  # list of unsupervised losses
+  # "pca_singleview" | "pca_multiview" | "temporal" | "unimodal_mse" | "unimodal_kl"
+  losses_to_use: ["pca_singleview","temporal"]
+  # backbone network:
+  # resnet18 | resnet34 | resnet50 | resnet101 | resnet152 | resnet50_contrastive
+  # resnet50_animalpose_apose | resnet50_animal_ap10k
+  # resnet50_human_jhmdb | resnet50_human_res_rle | resnet50_human_top_res
+  # efficientnet_b0 | efficientnet_b1 | efficientnet_b2
+  # vit_b_sam | vit_h_sam
+  backbone: resnet50_animal_ap10k
+  # prediction mode: regression | heatmap | heatmap_mhcrnn (context)
+  model_type: heatmap
+  # which heatmap loss to use
+  # mse | kl | js
+  heatmap_loss_type: mse
+  # directory name for model saving
+  base_model: chickadee
+  model_name: ${model.base_model}_posture
+  # field to hold parameters for the detector network, when using dynamic-crop algorithm
+  detector:
+    # backbone to use for detector network (same options as model.backbone)
+    backbone: ${model.backbone}
+    # detector losses to use (same options as model.losses_to_use)
+    losses_to_use: ${model.losses_to_use}
+    # directory for detector model saving
+    model_name: ${model.base_model}_detector
+
+dali:
+  general:
+    seed: 123456
+
+  base:
+    train:
+      sequence_length: 32
+    predict:
+      sequence_length: 96
+
+  context:
+    train:
+      batch_size: 16
+    predict:
+      sequence_length: 96
+
+losses:
+  # loss = projection onto the discarded eigenvectors
+  pca_multiview:
+    # weight in front of PCA loss
+    log_weight: 5.0
+    # predictions whould lie within the low-d subspace spanned by these components
+    components_to_keep: 3
+    # percentile of reprojection errors on train data below which pca loss is zeroed out
+    empirical_epsilon_percentile: 1.00
+    # doing eff_epsilon = percentile(error, empirical_epsilon_percentile) * empirical_epsilon_multiplier
+    empirical_epsilon_multiplier: 1.0
+    # absolute error (in pixels) below which pca loss is zeroed out; if not null, this
+    # parameter takes precedence over `empirical_epsilon_percentile`
+    epsilon: null
+  # loss = projection onto the discarded eigenvectors
+  pca_singleview:
+    # weight in front of PCA loss
+    log_weight: 5.0
+    # predictions whould lie within the low-d subspace spanned by components that describe this fraction of variance
+    components_to_keep: 0.99
+    # percentile of reprojection errors on train data below which pca loss is zeroed out
+    empirical_epsilon_percentile: 1.00
+    # doing eff_epsilon = percentile(error, empirical_epsilon_percentile) * empirical_epsilon_multiplier
+    empirical_epsilon_multiplier: 1.0
+    # absolute error (in pixels) below which pca loss is zeroed out; if not null, this
+    # parameter takes precedence over `empirical_epsilon_percentile`
+    epsilon: null
+  # loss = norm of distance between successive timepoints
+  temporal:
+    # weight in front of temporal loss
+    log_weight: 5.0
+    # for epsilon insensitive rectification
+    # (in pixels; diffs below this are not penalized)
+    epsilon: 20.0
+    # nan removal value.
+    # (in prob; heatmaps with max prob values are removed)
+    prob_threshold: 0.05
+  # loss = mse between model heatmap and idealized gaussian heatmap centered on softargmax
+  unimodal_mse:
+    # weight in front of unimodal_mse loss
+    log_weight: 5.0
+    # we compute this loss only for heatmaps with confidence prob > prob_threshold
+    prob_threshold: 0.05
+  # loss = kl divergence between model heatmap and idealized gaussian heatmap centered on softargmax
+  unimodal_kl:
+    # weight in front of unimodal_mse loss
+    log_weight: 5.0
+    # we compute this loss only for heatmaps with confidence prob > prob_threshold
+    prob_threshold: 0.05
+  # loss = jensen-shannon divergence between model heatmap and idealized gaussian heatmap centered on softargmax
+  unimodal_js:
+    # weight in front of unimodal_js loss
+    log_weight: 5.0
+    # we compute this loss only for heatmaps with confidence prob > prob_threshold
+    prob_threshold: 0.05
+
+eval:
+  # paths to the hydra config files in the output folder, OR absolute paths to such folders.
+  hydra_paths: [" "]
+  # predict?
+  predict_vids_after_training: true
+  # save labeled .mp4?
+  save_vids_after_training: false
+  fiftyone:
+    # will be the name of the dataset (Mongo DB) created by FiftyOne. for video dataset, we will append dataset_name + "_video"
+    dataset_name: test
+    build_speed: slow # "slow"/"fast". "fast" drops keypoint name and confidence information for faster processing.
+    # if you want to manually provide a different model name to be displayed in FiftyOne
+    model_display_names: ["test_model"]
+    # whether to launch the app from the script (True), or from ipython (and have finer control over the outputs)
+    launch_app_from_script: false
+
+    remote: true # for LAI, must be False
+    address: 127.0.0.1 # ip to launch the app on.
+    port: 5151 # port to launch the app on.
+
+    # whether to create a "videos" or "images" dataset, since the processes are the same
+    dataset_to_create: images
+  # str with an absolute path to a directory containing videos for prediction.
+  # set to null to skip automatic video prediction from train_hydra.py script
+  test_videos_directory: null
+  # str with an absolute path to directory in which you want to save .csv with predictions
+  saved_vid_preds_dir: null
+  # confidence threshold for plotting a vid
+  confidence_thresh_for_vid: 0.90
+  # str with absolute path to the video file you want plotted with keypoints
+  video_file_to_plot: null
+  # a list of strings, each points to a .csv file with predictions of a given model to the same video. will be combined with video_file_to_plot to make a visualization
+  pred_csv_files_to_plot: [" "]
+
+callbacks:
+  anneal_weight:
+    attr_name: total_unsupervised_importance
+    init_val: 0.0
+    increase_factor: 0.01
+    final_val: 1.0
+    freeze_until_epoch: 0
+
+hydra:
+  run:
+    dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/tests/data/test_datamodules.py
+++ b/tests/data/test_datamodules.py
@@ -126,7 +126,7 @@ def test_base_data_module_combined(cfg, base_data_module_combined):
     batch = next(iter(loader))
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
-    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs"]
+    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox"]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
     assert batch["labeled"]["keypoints"].shape == (train_size_labeled, num_targets)
@@ -152,7 +152,7 @@ def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
     batch = next(iter(loader))
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
-    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "heatmaps"]
+    assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox", "heatmaps"]
     assert list(batch["unlabeled"].keys()) == ["frames", "transforms"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
     assert batch["labeled"]["keypoints"].shape == (train_size_labeled, num_targets)

--- a/tests/data/test_datamodules.py
+++ b/tests/data/test_datamodules.py
@@ -127,7 +127,7 @@ def test_base_data_module_combined(cfg, base_data_module_combined):
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
     assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox"]
-    assert list(batch["unlabeled"].keys()) == ["frames", "transforms"]
+    assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
     assert batch["labeled"]["keypoints"].shape == (train_size_labeled, num_targets)
     assert batch["unlabeled"]["frames"].shape == (train_size_unlabeled, 3, im_height, im_width)
@@ -153,7 +153,7 @@ def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
     assert list(batch.keys())[0] == "labeled"
     assert list(batch.keys())[1] == "unlabeled"
     assert list(batch["labeled"].keys()) == ["images", "keypoints", "idxs", "bbox", "heatmaps"]
-    assert list(batch["unlabeled"].keys()) == ["frames", "transforms"]
+    assert list(batch["unlabeled"].keys()) == ["frames", "transforms", "bbox"]
     assert batch["labeled"]["images"].shape == (train_size_labeled, 3, im_height, im_width)
     assert batch["labeled"]["keypoints"].shape == (train_size_labeled, num_targets)
     assert batch["labeled"]["heatmaps"].shape == (

--- a/tests/utils/test_pca.py
+++ b/tests/utils/test_pca.py
@@ -33,7 +33,7 @@ def test_train_loader_iter(base_data_module_combined):
         assert type(batch["unlabeled"]) is dict
         assert type(batch["unlabeled"]["frames"]) is torch.Tensor
         assert check_lists_equal(
-            list(batch["labeled"].keys()), ["images", "keypoints", "idxs"]
+            list(batch["labeled"].keys()), ["images", "keypoints", "idxs", "bbox"]
         )
     assert image_counter == dataset_length
 


### PR DESCRIPTION
this applies to supervised & unsupervised training, and inference. Image size is also no longer part of a configuration. Image sizes are always computed on the fly, and passed as an entry in batch_dicts (bbox). This is used to transform predictions from resized to original coords. This should make the code long-term compatible with upcoming changes for a 2-stage dynamic-crop algorithm. At present, it only affects the code by rescaling all losses computed per-pixel, e.g. a temporal loss threshold of 20 pixels no applies to 20 pixels in the original, not resized, coords.