### PR TITLE
generalize keypoint access from dataframes in metrics

### DIFF
--- a/tests/data/test_utils.py
+++ b/tests/data/test_utils.py
@@ -403,12 +403,14 @@ def test_undo_affine_transform():
     keypoints = torch.normal(mean=torch.zeros((seq_len, n_keypoints, 2)))
 
     # test single transform
+    torch.manual_seed(0)
     transform_mat = torch.normal(mean=torch.zeros((2, 3)))
     keypoints_aug = torch.matmul(keypoints, transform_mat[:, :2].T) + transform_mat[:, -1]
     keypoints_noaug = undo_affine_transform(keypoints_aug, transform_mat)
     assert torch.allclose(keypoints, keypoints_noaug, atol=1e-4)
 
     # test individual transforms
+    torch.manual_seed(0)
     transform_mat = torch.normal(mean=torch.zeros((seq_len, 2, 3)))
     keypoints_aug = torch.bmm(
         keypoints, transform_mat[:, :, :2].transpose(2, 1)


### PR DESCRIPTION
* generalize keypoint access from dataframes in compute_metrics (necessary if we want to compute metrics on eks outputs, which have an additional z-score column for each keypoint)
* ensure pca losses are not computed in compute_metrics if datamodule is not passed
* do not monitor validation loss if not performing early stopping - this is important if there is no validation dataset (which happens when testing the app on a small number of labeled frames)
* set torch seed for undo_affine_transform test; failed once with a weird seed (first time)