### PR TITLE
ignore hidden "_labeled" folders in dlc to lp conversion

### DIFF
--- a/scripts/converters/dlc2lp.py
+++ b/scripts/converters/dlc2lp.py
@@ -24,7 +24,9 @@ if dlc_dir == lp_dir:
     raise NameError(f"dlc_dir and lp_dir cannot be the same")
 
 # find all labeled data in DLC project
-dirs = os.listdir(os.path.join(dlc_dir, "labeled-data"))
+dirs = [f for f in os.listdir(os.path.join(dlc_dir, "labeled-data")) if not f.startswith('.') if not f.endswith('_labeled')]
+
+
 dirs.sort()
 dfs = []
 for d in dirs:


### PR DESCRIPTION
The conversion script was failing as it was detecting folders in the "labeled_frames" folder that did not contain any frame data.

Examples of such folders are hidden folders, such as .DS_Store folders that MacOS generates.
The other examples are folders created by DeepLabCut when running the `check_labels` function (folders where labels are plotted on top of the frames).

This is a simple fix to filter out the potential problematic folders.

There is maybe a better/safer approach by generating a list of videos (from the videos folder or the config.yaml file) and then looking for folders in the labeled_videos folder that are exact matches of the basenames. 