### PR TITLE
remove augmentations for val/test data

### DIFF
--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -50,19 +50,16 @@ def video_pipe(
     """Generic video reader pipeline that loads videos, resizes, augments, and normalizes.
 
     Args:
-        filenames: list of absolute paths of video files to feed through
-            pipeline
+        filenames: list of absolute paths of video files to feed through pipeline
         resize_dims: [height, width] to resize raw frames
-        random_shuffle: True to grab random batches of frames from videos;
-            False to sequential read
+        random_shuffle: True to grab random batches of frames from videos; False to sequential read
         seed: random seed when `random_shuffle` is True
         sequence_length: number of frames to load per sequence
-        pad_sequences: allows creation of incomplete sequences if there is an
-            insufficient number of frames at the very end of the video
+        pad_sequences: allows creation of incomplete sequences if there is an insufficient number
+            of frames at the very end of the video
         initial_fill: size of the buffer that is used for random shuffling
         normalization_mean: mean values in (0, 1) to subtract from each channel
-        normalization_std: standard deviation values to subtract from each
-            channel
+        normalization_std: standard deviation values to subtract from each channel
         device: "cpu" | "gpu"
         name: pipeline name, used to string together DataNode elements
         step: number of frames to advance on each read
@@ -89,7 +86,7 @@ def video_pipe(
         dtype=types.DALIDataType.FLOAT,
         pad_last_batch=pad_last_batch,  # Important for context loaders
         file_list_include_preceding_frame=True,  # to get rid of dali warnings
-        skip_vfr_check = skip_vfr_check
+        skip_vfr_check=skip_vfr_check,
     )
     if resize_dims:
         video = fn.resize(video, size=resize_dims)

--- a/lightning_pose/data/utils.py
+++ b/lightning_pose/data/utils.py
@@ -291,17 +291,19 @@ def split_sizes_from_probabilities(
     elif test_probability is None:
         test_probability = 1.0 - train_probability - val_probability
 
-    assert (
-        test_probability + train_probability + val_probability == 1.0
-    )  # probabilities should add to one
+    # probabilities should add to one
+    assert test_probability + train_probability + val_probability == 1.0
+
+    # compute numbers from probabilities
     train_number = int(np.floor(train_probability * total_number))
     val_number = int(np.floor(val_probability * total_number))
-    test_number = (
-        total_number - train_number - val_number
-    )  # if we lose extra examples by flooring, send these to test_number
-    assert (
-        train_number + test_number + val_number == total_number
-    )  # assert that we're using all datapoints
+
+    # if we lose extra examples by flooring, send these to test_number
+    test_number = total_number - train_number - val_number
+
+    # assert that we're using all datapoints
+    assert train_number + test_number + val_number == total_number
+
     return [train_number, val_number, test_number]
 
 


### PR DESCRIPTION
previously there was a single augmentation pipeline that was applied to train, val, and test data. This meant that validation metrics reported during training were affected by augmentations, and that early stopping was also dependent on augmentations. This PR solves this issue by applying whatever augmentation pipeline is requested by the user through the config file to the train data; the val and test data are only ever resized.