### PR TITLE
Refactor state dict loading in vits.py

### DIFF
--- a/lightning_pose/models/backbones/vits.py
+++ b/lightning_pose/models/backbones/vits.py
@@ -89,14 +89,6 @@ def load_vit_backbone_checkpoint(base, checkpoint: str):
     for key, value in ckpt_vit_pretrain.items():
         if key.startswith("vit_mae."):
             model_key = key.replace("vit_mae.vit.", "")
-            # Skip known problematic layers with size mismatches
-            if any(prob in model_key for prob in [
-                "position_embeddings",
-                "patch_embeddings.projection",  # in case backbone was trained with grayscale imgs
-                "decoder_pos_embed",
-                "decoder_pred",
-            ]):
-                continue
             # Check if shapes match before including in state dict
             if model_key in base.vision_encoder.state_dict():
                 if base.vision_encoder.state_dict()[model_key].shape == value.shape:


### PR DESCRIPTION
Removed the skip condition for problematic layers in the state dict loading process.

closes #351 