### PR TITLE
skip tests that require figshare downloads

### DIFF
--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -1,6 +1,8 @@
 import shutil
 from pathlib import Path
 
+import pytest
+
 from lightning_pose.api.model import Model
 from tests.fetch_test_data import fetch_test_data_if_needed
 

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -4,6 +4,7 @@ import shutil
 from pathlib import Path
 from typing import Union
 
+import pytest
 from omegaconf import OmegaConf
 
 from lightning_pose.utils.cropzoom import (


### PR DESCRIPTION
We can no longer programmatically download test fixtures from figshare due to their new bot-protection protocols. Skipping tests that require this data until we find a solution so that PR checks are meaningful.