### PR TITLE
update readthedocs ubuntu build image

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
     python: "3.10"
     # You can also specify other tool versions:


### PR DESCRIPTION
readthedocs is deprecating the 20.04 ubuntu build on June 1, 2026.