### PR TITLE
no 3d aug if <3 valid 3d keypoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,183 @@
+# Claude Development Guidelines
+
+This file contains project-specific guidelines for Claude Code when working on this project.
+
+## Code Style
+
+### Comments
+- Use docstrings for all functions, classes, and modules
+- Follow Google-style docstrings
+- Add inline comments for complex logic
+- Avoid obvious comments
+- Comments should start with lowercase letters
+
+### Type Hints
+- Use type hints for all function parameters and return values
+- Import types from typing module when needed
+- use X | Y, list[X], dict[K, V] syntax; avoid typing imports for these
+
+### Imports
+- Group imports: standard library, third-party, local
+- Use absolute imports (e.g., `from <package_name>.<modlue_name> import func` not `from .<module_name> import func`)
+- Sort imports alphabetically within groups
+- Avoid wildcard imports
+
+### Code Formatting
+- Line length: 99 characters
+- Use 4 spaces for indentation
+- Follow PEP 8 conventions
+- Use meaningful variable names
+- Use idx for index
+- Use adjectives after nouns, such as idx_train and idx_test rather than train_idx and test_idx
+- Include newline at the end of every .py file
+- Do not allow trailing whitespace
+- Do not include whitespace for blank lines
+- Use single quotes for strings
+- Add a comma to the end of multi-line function arguments:
+```python
+foo(
+    param1,
+    param2,
+)
+```
+not
+```python
+foo(
+    param1,
+    param2
+)
+```
+
+### Misc
+- Use `pathlib.Path` instead of `os` for path handling
+- Use f-strings for all string interpolation, including `logger` calls and `print` statements — never `%s` formatting or `.format()`
+
+## Testing
+
+### Unit Tests
+- Use pytest framework
+- Test directory structure must mirror the source package structure exactly:
+  strip the `<package_name>/` prefix and prepend `tests/` — the rest of the path is identical.
+  `<package_name>/a/b/c.py` → `tests/a/b/test_c.py`, at every level of nesting without exception.
+  - Each subdirectory under `tests/` must have an `__init__.py`
+- Create test classes for each function
+- Use fixtures for common test data; place fixtures in a `conftest.py` in the same directory as the tests that use them
+- Test assets (e.g. sample images) live in an `assets/` subdirectory alongside the tests that use them
+- Aim for high test coverage
+- Test both success and failure cases
+
+### Test Structure
+```python
+class Test<function_name>:
+    """Test the function <function_name>."""
+
+    def test_<function_name>_<scenario>(self):
+        # Arrange
+        # Act
+        # Assert
+```
+
+### Mocking
+- Use unittest.mock for external dependencies
+- Mock at the boundary of your system
+- Use dependency injection when possible
+
+## Documentation
+
+### Docstrings
+```python
+def function_name(param1: Type1, param2: Type2) -> ReturnType:
+    """Brief description of function.
+    
+    Longer description if needed.
+    
+    Args:
+        param1: Description of param1
+        param2: Description of param2
+        
+    Returns:
+        Description of return value
+        
+    Raises:
+        ExceptionType: Description of when this exception is raised
+    """
+```
+If there are too many params for a single line, put one param per line, indented four spaces:
+```python
+def function_name(
+    param1: Type1,
+    param2: Type2,
+    param3: Type3,
+    param4: Type4,
+) -> ReturnType:
+```
+
+### Module Documentation
+- Every module should have a module-level docstring
+- Describe the purpose and main functionality
+
+## Error Handling
+
+### Exceptions
+- Use specific exception types
+- Provide meaningful error messages
+- Log errors appropriately
+- Use try/except blocks judiciously
+
+### Logging
+- Use Python's logging module
+- Include appropriate log levels (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+- Log important events and errors
+- Include context in log messages
+
+## Project Structure
+
+### Package Organization
+- Keep modules focused and cohesive
+- Use clear, descriptive module names
+- Group related functionality together
+- Avoid circular imports
+
+### File Naming
+- Use snake_case for Python files
+- Use descriptive names
+- Group related files in subdirectories
+
+## CLI Guidelines
+
+### Command Structure
+- Use subcommands for different operations
+- Provide clear help messages
+- Validate input parameters
+- Handle errors gracefully
+
+### Configuration
+- Use sensible defaults
+- Validate configuration before execution
+
+## Dependencies
+
+### Adding Dependencies
+- Only add dependencies that are truly needed
+- Prefer well-maintained packages
+- Do not pin versions
+- Update pyproject.toml and document changes
+
+### Version Management
+- Use semantic versioning
+- Update version in pyproject.toml
+- Tag releases appropriately
+
+## Git Workflow
+
+### Commits
+- Write clear, descriptive commit messages
+- Make atomic commits
+- Include tests with feature commits
+- Run tests before committing
+
+### Branches
+- Use feature branches for development
+- Keep branches focused and short-lived
+- Merge with pull requests
+- Delete merged branches

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 Lightning Pose is an end-to-end toolkit designed for robust multi-view and single-view animal
 pose estimation using advanced transformer architectures. It leverages Multi-View Transformers
 and patch-masking training to learn geometric relationships between views,
-resulting in strong performance on occlusions [Aharon, et al. 2025](https://arxiv.org/abs/2510.09903).
+resulting in strong performance on occlusions 
+[Aharon, Whiteway et al. 2026](https://www.biorxiv.org/content/10.64898/2026.04.20.719731v1).
 For single-view datasets it leverages temporal context and learned plausibility constraints for 
 strong performance in challenging scenarios [Biderman, Whiteway et al. 2024, Nature Methods](https://rdcu.be/dLP3z).
 It has a rich GUI that supports the end-to-end workflow: labeling, model management, and evaluation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@ Lightning Pose Homepage
    A new modern UI is available for multi-camera single-animal pose estimation,
    featuring end-to-end support for labeling, model management, and viewing predictions.
 
-   Since the initial release in late Jan 2026. Over 40 researchers from 8 countries have installed and run the app.
+   Since the initial release in late Jan 2026. Over 70 researchers from 10+ countries have installed and run the app.
 
    * **Get started:**
      Check out the :doc:`Create your first project <source/create_first_project>` tutorial and
@@ -153,22 +153,22 @@ The original Nature Methods 2024 paper that introduced Lightning Pose for single
 
          *Nature Methods* 21, 1316–1328 (2024)
 
-The 2025 paper that added robust multiview support using multiview transformers (MVT),
+The 2026 preprint that added robust multiview support using multiview transformers (MVT),
 patch masking, 3d image augmentation and losses, and multiview EKS.
 
-| **An Uncertainty-Aware Framework for Data-Efficient Multi-View Animal Pose Estimation**
-| Aharon, L., Lee, K., et al.
+| **Lightning Pose 3D: an uncertainty-aware framework for data-efficient multi-view animal pose estimation**
+| Aharon, L., Whiteway, M. R., et al.
 
 .. grid::
    :padding: 0
    :margin: 2 0 0 0
 
    .. grid-item::
-      .. button-link:: https://arxiv.org/abs/2510.09903
+      .. button-link:: https://www.biorxiv.org/content/10.64898/2026.04.20.719731v1
          :color: primary
          :outline:
 
-         arXiv Preprint (2025)
+         bioRxiv Preprint (2026)
 
 .. rst-class:: section-multi-view
 

--- a/lightning_pose/data/datasets.py
+++ b/lightning_pose/data/datasets.py
@@ -698,19 +698,6 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
             ))
         return images_resized
 
-    @staticmethod
-    def _sufficient_keypoints_for_augmentation(keypoints: np.ndarray) -> bool:
-        """Check if there are >=3 non-NaN keypoints in all views, required for augmentation."""
-        for keypoints_curr in keypoints:
-            # create a mask for valid keypoints
-            valid_mask = ~np.isnan(keypoints_curr).any(axis=1)
-            # apply the same mask to both original and augmented keypoints
-            keypoints_masked = keypoints_curr[valid_mask]
-            # ensure we have enough points for transformation
-            if len(keypoints_masked) < 3:
-                return False
-        return True
-
     def apply_3d_transforms(
         self,
         data_dict: dict,
@@ -744,8 +731,11 @@ class MultiviewHeatmapDataset(torch.utils.data.Dataset):
             # triangulate keypoints (2D -> 3D)
             keypoints_3d = camgroup.triangulate_fast(keypoints_2d.copy())
 
-            # if fewer than 3 valid keypoints in at least one view, cannot perform augmentation
-            if not self._sufficient_keypoints_for_augmentation(keypoints_2d):
+            # check number of properly triangulated points
+            valid_kps = np.sum(~(np.isnan(keypoints_3d).any(axis=1)))
+
+            # if fewer than 3 valid triangulated keypoints, cannot perform augmentation
+            if valid_kps < 3:
 
                 # keep 3d keypoints the same
                 keypoints_3d_aug = keypoints_3d.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "lightning-pose"
-version = "2.0.8"
+version = "2.0.9"
 description = "Semi-supervised pose estimation using pytorch lightning"
 license = "MIT"
 readme = "README.md"

--- a/tests/data/test_datasets.py
+++ b/tests/data/test_datasets.py
@@ -463,51 +463,6 @@ class TestMultiviewHeatmapDataset:
             # check that output is a different tensor (cloned)
             assert result[idx_view] is not images[idx_view]
 
-    def test_sufficient_keypoints_for_augmentation(self):
-        """Test _sufficient_keypoints_for_augmentation with various keypoint configurations."""
-
-        # Test case: All views have sufficient keypoints (>=3 valid)
-        kps_1 = np.array([
-            # View 1: 4 valid keypoints
-            [[100, 200], [150, 250], [250, 350]],
-            # View 2: 3 valid keypoints (minimum required)
-            [[110, 210], [160, 260], [210, 310]],
-            # View 3: 5 valid keypoints
-            [[120, 220], [170, 270], [320, 420]],
-        ])
-        assert MultiviewHeatmapDataset._sufficient_keypoints_for_augmentation(kps_1)
-
-        # Test case: Views with NaN values but still sufficient valid keypoints
-        kps_2 = np.array([
-            # View 1: 4 valid keypoints + 1 NaN keypoint
-            [[100, 200], [150, 250], [200, 300], [250, 350], [np.nan, np.nan]],
-            # View 2: 3 valid keypoints + 2 partial NaN keypoints
-            [[110, 210], [160, 260], [210, 310], [np.nan, np.nan], [np.nan, np.nan]],
-            # View 3: 5 valid keypoints + 1 completely NaN keypoint
-            [[120, 220], [170, 270], [220, 320], [270, 370], [320, 420]],
-        ])
-        assert MultiviewHeatmapDataset._sufficient_keypoints_for_augmentation(kps_2)
-
-        # Test case: Views with NaN values that result in insufficient valid keypoints
-        kps_3 = np.array([
-            # View 1: 3 valid keypoints + 2 NaN keypoints
-            [[100, 200], [150, 250], [200, 300], [np.nan, np.nan], [np.nan, np.nan]],
-            # View 2: Only 2 valid keypoints + 3 NaN/partial NaN keypoints
-            [[110, 210], [160, 260], [np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
-            # View 3: 4 valid keypoints
-            [[120, 220], [170, 270], [220, 320], [270, 370], [275, 375]],
-        ])
-        assert not MultiviewHeatmapDataset._sufficient_keypoints_for_augmentation(kps_3)
-
-        # Test case: All keypoints are NaN
-        kps_4 = np.array([
-            # View 1: All NaN keypoints
-            [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
-            # View 2: All NaN keypoints
-            [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
-        ])
-        assert not MultiviewHeatmapDataset._sufficient_keypoints_for_augmentation(kps_4)
-
     def test_get_2d_keypoints_from_example_dict_absolute_coords(self, multiview_heatmap_dataset):
 
         from lightning_pose.data.utils import normalized_to_bbox
@@ -878,6 +833,67 @@ class TestApply3DTransforms:
         datadict_2[view]["keypoints"].fill_(float("nan"))
         datadict_2[view]["keypoints"][:4] = torch.tensor([100.0, 100.0, 200.0, 200.0])
         no_change(datadict_2)
+
+    def test_mismatched_valid_keypoints_across_views(
+        self,
+        multiview_heatmap_dataset,
+        valid_data_dict,
+        camera_group,
+    ):
+        """Test fallback when each view has >=3 valid keypoints but the valid sets don't overlap.
+
+        Without the valid_kps < 3 check, this case would not be caught:
+        each view independently has >=3 valid keypoints, but no keypoint is valid in all views
+        simultaneously, so triangulation produces 0 valid 3D points. The code would then raise a
+        RuntimeError inside _transform_images.
+        """
+
+        num_kp_per_view = (
+            multiview_heatmap_dataset.num_keypoints // multiview_heatmap_dataset.num_views
+        )
+        view_names = multiview_heatmap_dataset.view_names
+
+        datadict = copy.deepcopy(valid_data_dict)
+
+        # View 0: keypoints 0,1,2 valid; rest NaN
+        kp0 = datadict[view_names[0]]["keypoints"]
+        kp0.fill_(float("nan"))
+        kp0[0:6] = torch.tensor([100.0, 100.0, 150.0, 100.0, 200.0, 100.0])
+
+        # View 1: keypoints 3,4,5 valid; rest NaN  (no overlap with view 0)
+        kp1 = datadict[view_names[1]]["keypoints"]
+        kp1.fill_(float("nan"))
+        kp1[6:12] = torch.tensor([110.0, 110.0, 160.0, 110.0, 210.0, 110.0])
+
+        # Each view has 3 valid keypoints, but valid_kps after triangulation == 0 < 3.
+        # Without the valid_kps < 3 guard this call raises RuntimeError.
+        np.random.seed(42)
+        torch.manual_seed(42)
+        datadict_aug, keypoints_3d_aug = multiview_heatmap_dataset.apply_3d_transforms(
+            data_dict=datadict,
+            camgroup=camera_group,
+            scale_params=(0.5, 2.0),
+            shift_param=0.5,
+        )
+
+        # Should fall back: 3D keypoints unchanged (all NaN, nothing triangulated)
+        original_keypoints_2d = (
+            multiview_heatmap_dataset._get_2d_keypoints_from_example_dict_absolute_coords(datadict)
+        )
+        original_3d = camera_group.triangulate_fast(original_keypoints_2d.copy())
+        assert np.allclose(keypoints_3d_aug.numpy(), original_3d, equal_nan=True, atol=1e-3)
+
+        # 2D keypoints should also be unchanged
+        for view in view_names:
+            original_kp = datadict[view]["keypoints"]
+            augmented_kp = datadict_aug[view]["keypoints"]
+            valid_mask = ~torch.isnan(original_kp)
+            assert torch.allclose(
+                original_kp[valid_mask],
+                augmented_kp[valid_mask],
+                equal_nan=True,
+                atol=1e-3,
+            )
 
     def test_all_nans(self, multiview_heatmap_dataset):
 


### PR DESCRIPTION
This PR address a corner case in 3D augmentation where each individual view contains at least 3 keypoints, but these are different across views and therefore result in <3 valid 3D keypoints. In this case the resulting image augmentation is not possible since it requires >=3 reprojected 3D keypoints to fit the affine transformation.

Closes #387 