### PR TITLE
 fix: handle ViTLayer tensor return in transformers >= 5.9

### DIFF
--- a/lightning_pose/models/heatmap_tracker_multiview.py
+++ b/lightning_pose/models/heatmap_tracker_multiview.py
@@ -201,7 +201,8 @@ class HeatmapTrackerMultiviewTransformer(BaseSupervisedTracker):
         else:
             hidden_states = embedding_output
             for layer in vit.layers:
-                hidden_states = layer(hidden_states)[0]
+                output = layer(hidden_states)
+                hidden_states = output[0] if isinstance(output, tuple) else output
             sequence_output = hidden_states
         outputs = self.backbone.vision_encoder.layernorm(sequence_output)  # type: ignore[operator]
         # shape: (batch, view * num_patches, embedding_dim)


### PR DESCRIPTION
Closes issue #448 

 - Fix `IndexError: dimension out of range` in `HeatmapTrackerMultiviewTransformer.forward_vit` when using
  `transformers >= 5.9`
  - Added `isinstance` check to handle both tuple (old) and tensor (new) return types from `ViTLayer.forward()`

What was wrong:

In `transformers >= 5.9`, `ViTLayer.forward()` returns a plain `torch.Tensor` instead of a tuple and the existing code 
`hidden_states = layer(hidden_states)[0]` indexes dimension 0 of the tensor itself selecting only the first batch element and collapsing the shape from `(batch, seq, hidden)` to `(seq, hidden)` and on the next layer iteration the attention module calls `.transpose(1, 2)` on the now 2D tensor and raises:

IndexError: Dimension out of range (expected to be in range of [-2, 1], but got 2)

the fix <-  This correctly extracts the hidden states regardless of whether the layer returns a tuple (transformers < 5.9) or a tensor (transformers >= 5.9): 

  tensor (transformers >= 5.9):
  ```python
  output = layer(hidden_states)
  hidden_states = output[0] if isinstance(output, tuple) else output

  
