### PR TITLE
fix: filter out unlabelled keypoints in SLEAP converter

### DIFF
--- a/scripts/converters/sleap2lp.py
+++ b/scripts/converters/sleap2lp.py
@@ -112,7 +112,11 @@ def extract_labels_from_pkg_slp(file_path: str, base_output_dir: str | None) -> 
                         keypoints_flat = []
                         for kp in points:
                             x, y = kp['x'], kp['y']
-                            if np.isnan(x) or np.isnan(y):
+                            if (
+                                np.isnan(x) or np.isnan(y)
+                                or not kp['visible']
+                                or not kp['complete']
+                            ):
                                 x, y = None, None
                             keypoints_flat.extend([x, y])
 


### PR DESCRIPTION
 - Filter out unlabelled keypoints in `sleap2lp.py` by checking the `visible` and `complete` flags from the SLEAP
  points dataset
  - Prevents arbitrary/random coordinates from being exported as valid labels

What was wrong: 

When creating keypoints in SLEAP arbitrary X/Y coordinates are assigned to all keypoints in the skeleton even those the user hasn't clicked on or positioned. The `sleap2lp.py` converter was only checking for `NaN` values before exporting coordinates but SLEAP's unlabelled points have real (arbitrary) coordinates - they just have `visible=False` and/or `complete=False so this meant that running the converter on a project with partially labelled frames would export incorrect, essentially random coordinates as valid training data which silently degrades the model performance

Fix:

 Added checks for `kp['visible']` and `kp['complete']` alongside the existing `np.isnan()` check, points that aren't both visible and complete are now exported as `None` (which becomes NaN in the CSV) which ends up matching Lightning Pose's convention for unlabelled keypoints


Closes #385