### PR TITLE
skip cuda installation on macOS

### DIFF
--- a/.github/workflows/tests_cpu.yml
+++ b/.github/workflows/tests_cpu.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install ffmpeg (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y ffmpeg
+
+      - name: Install ffmpeg (macOS)
+        if: runner.os == 'macOS'
+        run: brew install ffmpeg
+
       - name: Install dependencies (no DALI)
         run: |
           pip install -e ".[dev]" --no-deps

--- a/.github/workflows/tests_cpu.yml
+++ b/.github/workflows/tests_cpu.yml
@@ -49,4 +49,4 @@ jobs:
           EOF
 
       - name: Run CPU tests
-        run: pytest -m "not gpu" --timeout=300
+        run: pytest -m "not gpu"

--- a/.github/workflows/tests_cpu.yml
+++ b/.github/workflows/tests_cpu.yml
@@ -1,0 +1,44 @@
+name: Run CPU tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-cpu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies (no DALI)
+        run: |
+          pip install -e ".[dev]" --no-deps
+          python - <<'EOF'
+          import subprocess, tomllib
+          with open('pyproject.toml', 'rb') as f:
+              cfg = tomllib.load(f)
+          deps = (
+              cfg['project']['dependencies']
+              + cfg['project']['optional-dependencies']['dev']
+          )
+          deps = [d for d in deps if not d.startswith('nvidia-dali')]
+          subprocess.run(['pip', 'install'] + deps, check=True)
+          EOF
+
+      - name: Run CPU tests
+        run: pytest -m "not gpu" --timeout=300

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,20 @@ class Test<function_name>:
 - Mock at the boundary of your system
 - Use dependency injection when possible
 
+### GPU test markers
+Two pytest marks gate hardware-dependent tests:
+
+- `@pytest.mark.gpu` — test requires a CUDA GPU (uses a GPU trainer, DALI pipeline, or
+  moves tensors to CUDA). The CPU CI workflow runs `pytest -m "not gpu"` and will skip
+  these. **Any new test that needs a GPU must carry this mark.**
+- `@pytest.mark.multigpu` — test additionally requires two or more GPUs. Always paired
+  with `@pytest.mark.gpu` and `@pytest.mark.skipif(torch.cuda.device_count() < 2, ...)`.
+
+For files where every test needs a GPU, use a module-level `pytestmark = pytest.mark.gpu`
+instead of decorating each function individually. For parametrized tests with both CPU and
+GPU variants, apply the mark only to the GPU parameter via
+`pytest.param(..., marks=pytest.mark.gpu)` so the CPU variant still runs in CPU CI.
+
 ## Documentation
 
 ### Docstrings
@@ -167,6 +181,14 @@ def function_name(
 - Use semantic versioning
 - Update version in pyproject.toml
 - Tag releases appropriately
+
+### DALI imports
+`nvidia-dali-cuda110` is not installed on CPU-only machines (macOS, GPU-less Linux).
+Any import of `lightning_pose.data.dali` or `nvidia.dali` **must be done lazily** —
+inside the function or method body that uses it, not at the top of the file.
+The inline comment `# lazy: avoids ImportError on cpu-only installs` marks these sites.
+Adding a new top-level import from `dali.py` anywhere in the package or tests will break
+`import lightning_pose` on CPU machines.
 
 ## Git Workflow
 

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -1,5 +1,16 @@
 """Data pipelines based on efficient video reading by nvidia dali package.
 
+Import warning
+--------------
+``nvidia-dali-cuda110`` is not installed on CPU-only machines (macOS, GPU-less Linux), so
+importing this module at the top level of any other module will raise ``ImportError`` on those
+platforms and break ``import lightning_pose`` entirely. Always import from this module lazily,
+inside the function or method body that uses it::
+
+    def my_function(...):
+        from lightning_pose.data.dali import PrepareDALI  # lazy: avoids ImportError on cpu-only
+        ...
+
 Architecture overview
 ---------------------
 ``PrepareDALI`` is the entry point. Its ``__init__`` validates inputs and pre-computes

--- a/lightning_pose/data/dali.py
+++ b/lightning_pose/data/dali.py
@@ -28,14 +28,21 @@ import os
 from typing import Any, Literal
 
 import numpy as np
-import nvidia.dali.fn as fn
-import nvidia.dali.types as types
 import pandas as pd
 import torch
 import torch.nn.functional as F
-from nvidia.dali import pipeline_def
-from nvidia.dali.plugin.pytorch import DALIGenericIterator, LastBatchPolicy
 from omegaconf import DictConfig, ListConfig
+
+try:
+    import nvidia.dali.fn as fn
+    import nvidia.dali.types as types
+    from nvidia.dali import pipeline_def
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator, LastBatchPolicy
+except ImportError as e:
+    raise ImportError(
+        'nvidia-dali is required for video inference. '
+        'Install it with: pip install nvidia-dali-cuda110'
+    ) from e
 
 from lightning_pose.data import _IMAGENET_MEAN, _IMAGENET_STD
 from lightning_pose.data.datatypes import (

--- a/lightning_pose/data/datamodules.py
+++ b/lightning_pose/data/datamodules.py
@@ -21,7 +21,6 @@ from lightning.pytorch.utilities import CombinedLoader
 from omegaconf import DictConfig, ListConfig
 from torch.utils.data import DataLoader, Subset, random_split
 
-from lightning_pose.data.dali import PrepareDALI
 from lightning_pose.data.datatypes import SemiSupervisedDataLoaderDict
 from lightning_pose.data.utils import (
     compute_num_train_frames,
@@ -305,6 +304,7 @@ class UnlabeledDataModule(BaseDataModule):
 
     def setup_unlabeled(self) -> None:
         """Sets up the unlabeled data loader."""
+        from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
         dali_prep = PrepareDALI(
             train_stage="train",
             model_type="context" if self.dataset.do_context else "base",

--- a/lightning_pose/data/datatypes.py
+++ b/lightning_pose/data/datatypes.py
@@ -2,13 +2,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
 import pandas as pd
 import torch
 from jaxtyping import Float, Int
-from nvidia.dali.plugin.pytorch import DALIGenericIterator
+
+if TYPE_CHECKING:
+    from nvidia.dali.plugin.pytorch import DALIGenericIterator
 
 # to ignore imports for sphix-autoapidoc
 __all__ = [

--- a/lightning_pose/utils/predictions.py
+++ b/lightning_pose/utils/predictions.py
@@ -20,7 +20,6 @@ from moviepy import VideoFileClip
 from omegaconf import DictConfig, ListConfig
 
 from lightning_pose.callbacks import JSONInferenceProgressTracker
-from lightning_pose.data.dali import PrepareDALI
 from lightning_pose.data.datamodules import BaseDataModule, UnlabeledDataModule
 from lightning_pose.data.utils import count_frames
 
@@ -473,6 +472,7 @@ def predict_video(
     )
 
     filenames = [video_file] if not is_multiview else [[f] for f in video_file]
+    from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
     vid_pred_class = PrepareDALI(
         train_stage="predict",
         model_type=model_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "lightning-pose"
-version = "2.2.1"
+version = "2.3.0"
 description = "Semi-supervised pose estimation using pytorch lightning"
 license = "MIT"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "torch (<3.0.0)",
     "torchvision",
     "transformers>=4.57.5",
-    "nvidia-dali-cuda110",
+    "nvidia-dali-cuda110; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 
 [project.urls]
@@ -154,4 +154,4 @@ exclude_lines = [
 [tool.pytest.ini_options]
 testpaths = "tests"
 generate_report_on_test = "True"
-markers = ["multigpu"]
+markers = ["multigpu", "gpu"]

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -44,6 +44,8 @@ def _setup_test_model(tmp_path, request, multiview=False) -> Model:
 class TestPredictOnLabelCsv:
     """Test the predict_on_label_csv method."""
 
+    pytestmark = pytest.mark.gpu
+
     def test_predict_on_label_csv_singleview(self, tmp_path, request, toy_data_dir):
         """Singleview model writes predictions and per-metric error CSVs."""
         model = _setup_test_model(tmp_path, request)
@@ -89,6 +91,7 @@ class TestPredictOnLabelCsv:
 class TestPredictOnVideoFile:
     """Test the predict_on_video_file method."""
 
+    @pytest.mark.gpu
     def test_predict_on_video_file_singleview(self, tmp_path, request, toy_data_dir):
         """Singleview model writes prediction CSVs and optionally a labeled video."""
         model = _setup_test_model(tmp_path, request)
@@ -106,6 +109,7 @@ class TestPredictOnVideoFile:
         )
         assert (model.labeled_videos_dir() / "test_vid_labeled.mp4").is_file()
 
+    @pytest.mark.gpu
     def test_predict_on_video_file_with_multiview_model(self, tmp_path, request, toy_mdata_dir):
         """Multiview model can predict on a single video file."""
         model = _setup_test_model(tmp_path, request, multiview=True)
@@ -138,6 +142,7 @@ class TestPredictOnVideoFile:
 
         assert mock_pv.call_args.kwargs['bbox_file'] == bbox_file
 
+    @pytest.mark.gpu
     def test_predict_on_video_file_multiview(self, tmp_path, request, toy_mdata_dir):
         """predict_on_video_file_multiview writes predictions and labeled videos for all views."""
         model = _setup_test_model(tmp_path, request, multiview=True)
@@ -160,6 +165,8 @@ class TestPredictOnVideoFile:
 
 class TestPredictFrame:
     """Test the predict_frame method."""
+
+    pytestmark = pytest.mark.gpu
 
     def test_predict_frame_basic(self, tmp_path, request):
         """predict_frame returns keypoints and confidences for a synthetic RGB frame."""
@@ -236,6 +243,8 @@ class TestPredictFrame:
 
 class TestModelErrors:
     """Test that Model public methods raise informative errors on bad inputs."""
+
+    pytestmark = pytest.mark.gpu
 
     @pytest.fixture()
     def singleview_model(self, tmp_path, request):

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -320,6 +320,8 @@ class TestModelErrors:
 class TestBuildDatamodulePred:
     """Test the _build_datamodule_pred helper."""
 
+    pytestmark = pytest.mark.gpu
+
     def test_build_datamodule_pred_imgaug_reset_to_default(self, cfg):
         """imgaug pipeline is resize-only regardless of the training config."""
         cfg_copy = copy.deepcopy(cfg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,6 @@ from lightning_pose.data import (
     get_dataset,
     get_imgaug_transform,
 )
-from lightning_pose.data.dali import LitDaliWrapper, PrepareDALI
 from lightning_pose.data.datamodules import BaseDataModule, UnlabeledDataModule
 from lightning_pose.data.datasets import (
     BaseTrackingDataset,
@@ -526,8 +525,9 @@ def multiview_heatmap_data_module_combined_context(
 
 
 @pytest.fixture
-def video_dataloader(cfg, base_dataset, video_list) -> Generator[LitDaliWrapper, None, None]:
+def video_dataloader(cfg, base_dataset, video_list):
     """Create a prediction dataloader for a new video."""
+    from lightning_pose.data.dali import PrepareDALI
 
     # setup
     vid_pred_class = PrepareDALI(
@@ -552,8 +552,9 @@ def video_dataloader_multiview(
     cfg_multiview,
     multiview_heatmap_dataset,
     video_list_multiview,
-) -> Generator[LitDaliWrapper, None, None]:
+):
     """Create a prediction dataloader for a new video."""
+    from lightning_pose.data.dali import PrepareDALI
 
     # setup
     vid_pred_class = PrepareDALI(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -527,7 +527,7 @@ def multiview_heatmap_data_module_combined_context(
 @pytest.fixture
 def video_dataloader(cfg, base_dataset, video_list):
     """Create a prediction dataloader for a new video."""
-    from lightning_pose.data.dali import PrepareDALI
+    from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
 
     # setup
     vid_pred_class = PrepareDALI(
@@ -554,7 +554,7 @@ def video_dataloader_multiview(
     video_list_multiview,
 ):
     """Create a prediction dataloader for a new video."""
-    from lightning_pose.data.dali import PrepareDALI
+    from lightning_pose.data.dali import PrepareDALI  # avoids ImportError on cpu-only installs
 
     # setup
     vid_pred_class = PrepareDALI(

--- a/tests/data/test_dali.py
+++ b/tests/data/test_dali.py
@@ -9,6 +9,8 @@ import pandas as pd
 import pytest
 import torch
 
+pytest.importorskip('nvidia.dali', reason='nvidia-dali not installed')
+
 from lightning_pose.data import dali as dali_module
 from lightning_pose.data.dali import LitDaliWrapper, PrepareDALI, video_pipe
 from lightning_pose.data.datatypes import UnlabeledBatchDict
@@ -17,6 +19,7 @@ from lightning_pose.data.datatypes import UnlabeledBatchDict
 class TestVideoPipe:
     """Test the video_pipe function."""
 
+    @pytest.mark.gpu
     def test_single_view(self, video_list):
         """Single-view pipeline yields (frames, transforms, frame_size) tuples of correct shape."""
         batch_size = 2
@@ -42,6 +45,7 @@ class TestVideoPipe:
 
         del pipe
 
+    @pytest.mark.gpu
     def test_multiview(self, video_list):
         """Multi-view pipeline yields per-view tuples; identical videos produce matching frames."""
         batch_size = 2
@@ -77,6 +81,7 @@ class TestVideoPipe:
 class TestPrepareDALI:
     """Test the PrepareDALI class."""
 
+    @pytest.mark.gpu
     def test_single_view_base_predict(self, cfg, video_list):
         """Base model predict loader yields batches of the configured sequence length and dims."""
         im_height = 256
@@ -103,6 +108,7 @@ class TestPrepareDALI:
             batch_idx += 1
         assert batch_idx == num_iters - 1
 
+    @pytest.mark.gpu
     def test_single_view_context_predict(self, cfg, video_list):
         """Context model predict loader yields batches of the context sequence length and dims."""
         im_height = 256
@@ -151,6 +157,7 @@ class TestPrepareDALI:
                 resize_dims=[256, 256],
             )
 
+    @pytest.mark.gpu
     def test_multiview_base_train_and_predict(self, cfg_multiview, video_list):
         """Multi-view base model batches have correct shape for train and predict stages."""
         im_height = 256
@@ -177,6 +184,7 @@ class TestPrepareDALI:
             assert batch['transforms'].shape == (num_views, 1, 1)
             assert batch['bbox'].shape == (batch_size, num_views * 4)
 
+    @pytest.mark.gpu
     def test_multiview_context_train_and_predict(self, cfg_multiview, video_list):
         """Multi-view context model batches have correct shape for train and predict stages."""
         im_height = 256
@@ -203,6 +211,7 @@ class TestPrepareDALI:
             assert batch['transforms'].shape == (num_views, 1, 1)
             assert batch['bbox'].shape == (batch_size, num_views * 4)
 
+    @pytest.mark.gpu
     def test_multiview_synchronized_frames(self, cfg_multiview, video_list):
         """Shared reader seed keeps per-view frames synchronized under random shuffle."""
         num_views = 3

--- a/tests/data/test_datamodules.py
+++ b/tests/data/test_datamodules.py
@@ -233,6 +233,7 @@ def test_subsampling_of_training_frames(base_dataset):
         BaseDataModule(base_dataset, train_frames=train_frames)
 
 
+@pytest.mark.gpu
 def test_base_data_module_combined(cfg, base_data_module_combined):
 
     im_height = cfg.data.image_resize_dims.height
@@ -272,6 +273,7 @@ def test_base_data_module_combined(cfg, base_data_module_combined):
     assert image_counter == dataset_length
 
 
+@pytest.mark.gpu
 def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
 
     im_height = cfg.data.image_resize_dims.height
@@ -300,6 +302,7 @@ def test_heatmap_data_module_combined(cfg, heatmap_data_module_combined):
     assert batch["unlabeled"]["frames"].shape == (train_size_unlabel, 3, im_height, im_width)
 
 
+@pytest.mark.gpu
 def test_multiview_heatmap_data_module_combined(
     cfg_multiview,
     multiview_heatmap_data_module_combined,
@@ -346,6 +349,7 @@ def test_multiview_heatmap_data_module_combined(
     assert batch["unlabeled"]["bbox"].shape == (train_size_unlabeled, num_views * 4)
 
 
+@pytest.mark.gpu
 def test_heatmap_data_module_combined_context(cfg, heatmap_data_module_combined_context):
 
     im_height = cfg.data.image_resize_dims.height
@@ -378,6 +382,7 @@ def test_heatmap_data_module_combined_context(cfg, heatmap_data_module_combined_
     assert batch["unlabeled"]["frames"].shape == (train_size_unlabel, 3, im_height, im_width)
 
 
+@pytest.mark.gpu
 def test_multiview_heatmap_data_module_combined_context(
     cfg_multiview,
     multiview_heatmap_data_module_combined_context,

--- a/tests/data/test_extractor.py
+++ b/tests/data/test_extractor.py
@@ -6,28 +6,28 @@ from lightning_pose.data.extractor import DataExtractor
 class TestDataExtractor:
     """Test the DataExtractor class."""
 
-    def test_data_extractor_single_view(self, base_data_module_combined):
+    def test_data_extractor_single_view(self, base_data_module):
         num_frames = (
-            len(base_data_module_combined.dataset)
-            * base_data_module_combined.train_probability
+            len(base_data_module.dataset)
+            * base_data_module.train_probability
         )
         keypoint_tensor, _ = DataExtractor(
-            data_module=base_data_module_combined, cond='train'
+            data_module=base_data_module, cond='train'
         )()
         assert keypoint_tensor.shape == (num_frames, 34)
 
         keypoint_tensor, images_tensor = DataExtractor(
-            data_module=base_data_module_combined, cond='train', extract_images=True
+            data_module=base_data_module, cond='train', extract_images=True
         )()
         assert images_tensor is not None
         assert images_tensor.shape == (num_frames, 3, 128, 128)
 
-    def test_data_extractor_multiview(self, multiview_heatmap_data_module_combined):
+    def test_data_extractor_multiview(self, multiview_heatmap_data_module):
         num_frames = (
-            len(multiview_heatmap_data_module_combined.dataset)
-            * multiview_heatmap_data_module_combined.train_probability
+            len(multiview_heatmap_data_module.dataset)
+            * multiview_heatmap_data_module.train_probability
         )
         keypoint_tensor, _ = DataExtractor(
-            data_module=multiview_heatmap_data_module_combined, cond='train'
+            data_module=multiview_heatmap_data_module, cond='train'
         )()
         assert keypoint_tensor.shape == (num_frames, 28)

--- a/tests/data/test_factory.py
+++ b/tests/data/test_factory.py
@@ -251,6 +251,7 @@ class TestGetDataModule:
                 == cfg.dali.base.train.sequence_length / cfg.training.num_gpus)
         # context batch size is more nuanced, tested separately
 
+    @pytest.mark.gpu
     def test_get_data_module_multi_gpu_batch_size_adjustment_ceiling(
         self, cfg, heatmap_dataset, toy_data_dir,
     ):
@@ -281,6 +282,7 @@ class TestGetDataModule:
         )
         # context batch size is more nuanced, tested separately
 
+    @pytest.mark.gpu
     def test_get_data_module_multi_gpu_context_batch_size_adjustment(
         self, cfg, heatmap_dataset, toy_data_dir,
     ):

--- a/tests/losses/test_losses.py
+++ b/tests/losses/test_losses.py
@@ -221,7 +221,10 @@ class TestHeatmapJSLoss:
 class TestPCALoss:
     """Test the PCALoss class."""
 
-    @pytest.mark.parametrize('device', ['cpu', f'cuda:{torch.cuda.current_device()}'])
+    @pytest.mark.parametrize('device', [
+        'cpu',
+        pytest.param(f'cuda:{torch.cuda.current_device()}', marks=pytest.mark.gpu),
+    ])
     def test_pca_singleview_loss(self, cfg, base_data_module, device):
         """Test singleview PCA loss produces positive loss on toy data."""
         pca_loss = PCALoss(
@@ -248,7 +251,10 @@ class TestPCALoss:
         with pytest.raises(ValueError):
             PCALoss(loss_name='pca_multiview', data_module=base_data_module)
 
-    @pytest.mark.parametrize('device', ['cpu', f'cuda:{torch.cuda.current_device()}'])
+    @pytest.mark.parametrize('device', [
+        'cpu',
+        pytest.param(f'cuda:{torch.cuda.current_device()}', marks=pytest.mark.gpu),
+    ])
     def test_pca_multiview_loss_on_toy_dataset(self, cfg, base_data_module, device):
         """Test multiview PCA loss produces expected shapes and positive loss on toy data."""
         pca_loss = PCALoss(
@@ -277,7 +283,10 @@ class TestPCALoss:
         assert logs[1]['name'] == 'pca_multiview_weight'
         assert logs[1]['value'] == pca_loss.weight
 
-    @pytest.mark.parametrize('device', ['cpu', f'cuda:{torch.cuda.current_device()}'])
+    @pytest.mark.parametrize('device', [
+        'cpu',
+        pytest.param(f'cuda:{torch.cuda.current_device()}', marks=pytest.mark.gpu),
+    ])
     def test_pca_multiview_loss_on_fake_dataset(self, cfg, base_data_module, device):
         """Test that multiview PCA loss is zero for data exactly in the PCA subspace."""
         # TODO: this is not how we currently compute reprojection; we now add mean in final stage

--- a/tests/losses/test_losses.py
+++ b/tests/losses/test_losses.py
@@ -223,7 +223,7 @@ class TestPCALoss:
 
     @pytest.mark.parametrize('device', [
         'cpu',
-        pytest.param(f'cuda:{torch.cuda.current_device()}', marks=pytest.mark.gpu),
+        pytest.param('cuda:0', marks=pytest.mark.gpu),
     ])
     def test_pca_singleview_loss(self, cfg, base_data_module, device):
         """Test singleview PCA loss produces positive loss on toy data."""
@@ -253,7 +253,7 @@ class TestPCALoss:
 
     @pytest.mark.parametrize('device', [
         'cpu',
-        pytest.param(f'cuda:{torch.cuda.current_device()}', marks=pytest.mark.gpu),
+        pytest.param('cuda:0', marks=pytest.mark.gpu),
     ])
     def test_pca_multiview_loss_on_toy_dataset(self, cfg, base_data_module, device):
         """Test multiview PCA loss produces expected shapes and positive loss on toy data."""
@@ -285,7 +285,7 @@ class TestPCALoss:
 
     @pytest.mark.parametrize('device', [
         'cpu',
-        pytest.param(f'cuda:{torch.cuda.current_device()}', marks=pytest.mark.gpu),
+        pytest.param('cuda:0', marks=pytest.mark.gpu),
     ])
     def test_pca_multiview_loss_on_fake_dataset(self, cfg, base_data_module, device):
         """Test that multiview PCA loss is zero for data exactly in the PCA subspace."""

--- a/tests/models/test_heatmap_tracker.py
+++ b/tests/models/test_heatmap_tracker.py
@@ -4,6 +4,8 @@ import copy
 
 import pytest
 
+pytestmark = pytest.mark.gpu
+
 
 def test_supervised_heatmap(
     cfg,

--- a/tests/models/test_heatmap_tracker_mhcrnn.py
+++ b/tests/models/test_heatmap_tracker_mhcrnn.py
@@ -2,6 +2,10 @@
 
 import copy
 
+import pytest
+
+pytestmark = pytest.mark.gpu
+
 
 def test_supervised_heatmap_mhcrnn(
     cfg,

--- a/tests/models/test_heatmap_tracker_multiview.py
+++ b/tests/models/test_heatmap_tracker_multiview.py
@@ -10,6 +10,7 @@ from lightning_pose.data.datasets import MultiviewHeatmapDataset
 from lightning_pose.data.datatypes import MultiviewHeatmapLabeledExampleDict
 
 
+@pytest.mark.gpu
 def test_multiview_transformer_vits_dino(
     cfg_multiview,
     multiview_heatmap_dataset,
@@ -44,6 +45,7 @@ def test_multiview_transformer_vits_dino(
     )
 
 
+@pytest.mark.gpu
 def test_multiview_transformer_vits_dinov2(
     cfg_multiview,
     multiview_heatmap_dataset,
@@ -78,6 +80,7 @@ def test_multiview_transformer_vits_dinov2(
     )
 
 
+@pytest.mark.gpu
 def test_multiview_transformer_vitb_imagenet(
     cfg_multiview,
     multiview_heatmap_dataset,
@@ -140,6 +143,7 @@ def test_multiview_transformer_vitb_sam_raises(
         get_model(cfg=cfg_tmp, data_module=data_module, loss_factories={'supervised': None})
 
 
+@pytest.mark.gpu
 def test_semisupervised_multiview_transformer_temporal(
     cfg_multiview,
     multiview_heatmap_dataset,

--- a/tests/models/test_regression_tracker.py
+++ b/tests/models/test_regression_tracker.py
@@ -2,6 +2,10 @@
 
 import copy
 
+import pytest
+
+pytestmark = pytest.mark.gpu
+
 
 def test_supervised_regression(
     cfg,

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -382,6 +382,7 @@ class TestCalculateStepsPerEpoch:
         n_batches = calculate_steps_per_epoch(base_data_module)
         assert n_batches == 25  # ceil (49 / 2)
 
+    @pytest.mark.gpu
     def test_calculate_steps_per_epoch_unsupervised(self, cfg, base_dataset, toy_data_dir):
         """Test the computation of steps per epoch."""
         video_dir = os.path.join(toy_data_dir, 'videos')

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -48,6 +48,7 @@ def _test_cfg(cfg):
     return cfg_tmp
 
 
+@pytest.mark.gpu
 def test_train_singleview(cfg, tmp_path):
     cfg = _test_cfg(cfg)
     cfg.model.model_type = "heatmap"
@@ -126,6 +127,7 @@ def test_train_singleview_detector_outputs(cfg, tmp_path):
     assert (image_pred_dir / "predictions_pixel_error.csv").is_file()
 
 
+@pytest.mark.gpu
 def test_train_multiview(cfg_multiview, tmp_path):
     from lightning_pose.train import train
 
@@ -193,6 +195,7 @@ def _execute_multi_gpu_test(cfg, tmp_path, pytestconfig):
     assert process.returncode == 0
 
 
+@pytest.mark.gpu
 @pytest.mark.multigpu  # allow running only multi_gpu tests with `pytest -m multigpu`
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs required.")
 def test_train_multi_gpu_supervised(cfg, tmp_path, pytestconfig):
@@ -205,6 +208,7 @@ def test_train_multi_gpu_supervised(cfg, tmp_path, pytestconfig):
     _execute_multi_gpu_test(cfg, tmp_path, pytestconfig)
 
 
+@pytest.mark.gpu
 @pytest.mark.multigpu  # allow running only multi_gpu tests with `pytest -m multigpu`
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs required.")
 def test_train_multi_gpu_unsupervised(cfg, tmp_path, pytestconfig):

--- a/tests/test_training/test_lr.py
+++ b/tests/test_training/test_lr.py
@@ -1,10 +1,13 @@
 import math
 from pathlib import Path
 
+import pytest
 import tbparse
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from lightning_pose.train import train
+
+pytestmark = pytest.mark.gpu
 
 
 def _get_base_cfg(cfg):

--- a/tests/test_training/test_train_duration.py
+++ b/tests/test_training/test_train_duration.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 
+import pytest
 import tbparse
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from lightning_pose.train import train
+
+pytestmark = pytest.mark.gpu
 
 
 def _get_base_cfg(cfg):

--- a/tests/utils/test_cropzoom.py
+++ b/tests/utils/test_cropzoom.py
@@ -135,7 +135,15 @@ def compare_directories(dir1: Path, dir2: Path) -> int | dict:
         # fails on mp4s because metadata is different, no quick fix
         if common_file.find('.mp4') > -1:
             continue
-        if filecmp.cmp(dir1 / common_file, dir2 / common_file, shallow=False):
+        # PNG byte output can differ across platforms (zlib compression level / metadata);
+        # compare pixel arrays instead of raw bytes
+        if common_file.endswith('.png'):
+            arr1 = np.array(Image.open(dir1 / common_file))
+            arr2 = np.array(Image.open(dir2 / common_file))
+            match = arr1.shape == arr2.shape and np.array_equal(arr1, arr2)
+        else:
+            match = filecmp.cmp(dir1 / common_file, dir2 / common_file, shallow=False)
+        if match:
             num_matches += 1
         else:
             results["mismatch"].append(common_file)

--- a/tests/utils/test_pca.py
+++ b/tests/utils/test_pca.py
@@ -20,17 +20,17 @@ def check_lists_equal(list_0: list, list_1: list) -> bool:
 class TestKeypointPCA:
     """Test the class KeypointPCA."""
 
-    def test_keypoint_pca_singleview(self, cfg, base_data_module_combined):
+    def test_keypoint_pca_singleview(self, cfg, base_data_module):
         num_train_ims = int(
-            len(base_data_module_combined.dataset)
-            * base_data_module_combined.train_probability
+            len(base_data_module.dataset)
+            * base_data_module.train_probability
         )
-        num_keypoints = base_data_module_combined.dataset.num_keypoints
+        num_keypoints = base_data_module.dataset.num_keypoints
         num_keypoints_for_pca = len(cfg.data.columns_for_singleview_pca)
 
         kp_pca = KeypointPCA(
             loss_type="pca_singleview",
-            data_module=base_data_module_combined,
+            data_module=base_data_module,
             components_to_keep=0.99,
             empirical_epsilon_percentile=1.0,
             columns_for_singleview_pca=cfg.data.columns_for_singleview_pca,
@@ -63,7 +63,7 @@ class TestKeypointPCA:
         pred_keypoints = torch.rand(size=(n_batches, n_keypoints * 2), device="cpu")
         singleview_pca = KeypointPCA(
             loss_type="pca_singleview",
-            data_module=base_data_module_combined,
+            data_module=base_data_module,
             components_to_keep=6,
             empirical_epsilon_percentile=1.0,
             columns_for_singleview_pca=cfg.data.columns_for_singleview_pca,
@@ -77,10 +77,10 @@ class TestKeypointPCA:
         err = singleview_pca.compute_reprojection_error(data_arr=data_arr)
         assert err.shape == (n_batches, 14)
 
-    def test_keypoint_pca_median_centering(self, cfg, base_data_module_combined):
+    def test_keypoint_pca_median_centering(self, cfg, base_data_module):
         kp_pca = KeypointPCA(
             loss_type="pca_singleview",
-            data_module=base_data_module_combined,
+            data_module=base_data_module,
             components_to_keep=0.99,
             empirical_epsilon_percentile=1.0,
             columns_for_singleview_pca=[0, 1, 2],
@@ -110,10 +110,10 @@ class TestKeypointPCA:
             ),
         )
 
-    def test_keypoint_pca_mean_centering(self, cfg, base_data_module_combined):
+    def test_keypoint_pca_mean_centering(self, cfg, base_data_module):
         kp_pca = KeypointPCA(
             loss_type="pca_singleview",
-            data_module=base_data_module_combined,
+            data_module=base_data_module,
             components_to_keep=0.99,
             empirical_epsilon_percentile=1.0,
             columns_for_singleview_pca=[0, 1, 2],
@@ -146,20 +146,20 @@ class TestKeypointPCA:
     def test_keypoint_pca_multiview(
         self,
         cfg,
-        base_data_module_combined,
+        base_data_module,
         cfg_multiview,
-        multiview_heatmap_data_module_combined,
+        multiview_heatmap_data_module,
     ):
         num_train_ims = (
-            len(base_data_module_combined.dataset)
-            * base_data_module_combined.train_probability
+            len(base_data_module.dataset)
+            * base_data_module.train_probability
         )
-        num_keypoints = base_data_module_combined.dataset.num_keypoints
+        num_keypoints = base_data_module.dataset.num_keypoints
         num_keypoints_both_views = 7
 
         kp_pca = KeypointPCA(
             loss_type="pca_multiview",
-            data_module=base_data_module_combined,
+            data_module=base_data_module,
             components_to_keep=3,
             empirical_epsilon_percentile=0.3,
             mirrored_column_matches=cfg.data.mirrored_column_matches,
@@ -189,7 +189,7 @@ class TestKeypointPCA:
         # make sure we don't get errors when using a true multiview dataset
         kp_pca_2 = KeypointPCA(
             loss_type="pca_multiview",
-            data_module=multiview_heatmap_data_module_combined,
+            data_module=multiview_heatmap_data_module,
             components_to_keep=3,
             empirical_epsilon_percentile=0.3,
             mirrored_column_matches=cfg_multiview.data.mirrored_column_matches,

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -65,6 +65,7 @@ class TestPredictDataset:
         mock.config.cfg = cfg_tmp
         return mock
 
+    @pytest.mark.gpu
     def test_predict_dataset_explicit_cfg(self, mock_model, cfg, heatmap_data_module, tmpdir):
         """Predictions are written when cfg is passed explicitly."""
         predict_dataset(
@@ -74,6 +75,7 @@ class TestPredictDataset:
             cfg=cfg,
         )
 
+    @pytest.mark.gpu
     def test_predict_dataset_cfg_fallback(self, mock_model, heatmap_data_module, tmpdir):
         """Predictions are written when cfg falls back to model.config.cfg."""
         predict_dataset(

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -117,7 +117,7 @@ class TestPredictVideoBboxFile:
 
         with (
             patch('lightning_pose.utils.predictions.count_frames', return_value=3),
-            patch('lightning_pose.utils.predictions.PrepareDALI', mock_dali),
+            patch('lightning_pose.data.dali.PrepareDALI', mock_dali),
             patch('lightning_pose.utils.predictions.pl.Trainer'),
             patch('lightning_pose.utils.predictions.PredictionHandler'),
         ):
@@ -137,7 +137,7 @@ class TestPredictVideoBboxFile:
         mock_dali = MagicMock()
 
         with (
-            patch('lightning_pose.utils.predictions.PrepareDALI', mock_dali),
+            patch('lightning_pose.data.dali.PrepareDALI', mock_dali),
             patch('lightning_pose.utils.predictions.pl.Trainer'),
             patch('lightning_pose.utils.predictions.PredictionHandler'),
         ):

--- a/tests/utils/test_predictions.py
+++ b/tests/utils/test_predictions.py
@@ -110,6 +110,7 @@ class TestPredictVideoBboxFile:
         df.to_csv(path)
         return path, df
 
+    @pytest.mark.gpu
     def test_bbox_df_forwarded_to_prepare_dali(self, tmp_path, mock_model, bbox_csv):
         """PrepareDALI receives the loaded bbox_df when bbox_file is provided."""
         bbox_file, _ = bbox_csv
@@ -132,6 +133,7 @@ class TestPredictVideoBboxFile:
         assert list(call_kwargs['bbox_df'].columns) == ['x', 'y', 'h', 'w']
         assert len(call_kwargs['bbox_df']) == 3
 
+    @pytest.mark.gpu
     def test_none_bbox_df_when_bbox_file_not_provided(self, tmp_path, mock_model):
         """PrepareDALI receives bbox_df=None when bbox_file is not provided."""
         mock_dali = MagicMock()


### PR DESCRIPTION
`nvidia-dali-cuda110` was a hard dependency that made `pip install lightning-pose` fail on macOS (and any machine without CUDA drivers). This means that the lightning pose app cannot be installed on macOS for labeling purposes.

This PR fixes that in two ways:
1. Platform marker: `nvidia-dali-cuda110` now carries ; `sys_platform == 'linux' and platform_machine == 'x86_64'` in pyproject.toml, so it is silently skipped on macOS. No change to the install command for users.
2. Conditional DALI imports: dali.py wraps the nvidia imports in try/except ImportError with a clear error message; datatypes.py moves the DALIGenericIterator import under TYPE_CHECKING. This allows the package to import cleanly on machines where DALI is not installed — labeling and other non-video functionality works without it.
3. pytest.mark.gpu marker: GPU-requiring tests are now annotated with @pytest.mark.gpu (or module-level pytestmark), enabling pytest -m "not gpu" to run only CPU-safe tests. The test_dali.py module is guarded with test.importorskip('nvidia.dali') so it skips cleanly when DALI is absent.
4. CPU CI workflow (.github/workflows/tests_cpu.yml): runs on both ubuntu-latest and macos-latest, installs all dependencies except DALI, and runs pytest -m "not gpu".