### PR TITLE
improve huggingface dataset download reliability

### DIFF
--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -6,13 +6,14 @@ Scripts for running parallel Lightning Pose training sweeps, either on
 ## How it works
 
 `run_sweep.py` builds the cartesian product of all sweep dimensions defined in
-`sweep_config.yaml` and launches one Lightning AI Job per combination.
-Each job runs `run_single_job.py`, which:
+`sweep_config.yaml`. Before launching any jobs, it pre-downloads each unique
+dataset into a shared teamspace cache — so the download happens exactly once,
+regardless of how many jobs share that dataset. It then launches one Lightning AI
+Job per combination. Each job runs `run_single_job.py`, which:
 
-1. Downloads the dataset from HuggingFace (selectively — videos only when needed)
+1. Uses the pre-cached dataset on teamspace (skips downloading if already present)
 2. Calls `litpose train` with the appropriate config and overrides
 3. Deletes model weights (`.ckpt`) to save storage
-4. Cleans up the downloaded dataset
 
 Results are written to teamspace storage and persist after each job ends.
 
@@ -127,11 +128,8 @@ Key fields:
 ### Dataset caching
 
 Downloaded datasets are cached in `output.dataset_cache_dir` (default:
-`/teamspace/lightning_storage/datasets`). Before launching any jobs,
-`run_sweep.py` pre-downloads each unique dataset into the cache. This means
-the download happens exactly once regardless of sweep size, and all jobs find
-the cache already populated — avoiding both HuggingFace rate limits and race
-conditions from simultaneous first-time downloads.
+`/teamspace/lightning_storage/datasets`), avoiding HuggingFace rate limits and
+race conditions from simultaneous first-time downloads.
 
 For local runs, set `output.dataset_cache_dir` in `sweep_config.yaml` to a
 local path, or pass `--dataset_cache_dir /your/path` directly to

--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -129,7 +129,13 @@ Key fields:
 
 Downloaded datasets are cached in `output.dataset_cache_dir` (default:
 `/teamspace/lightning_storage/datasets`), avoiding HuggingFace rate limits and
-race conditions from simultaneous first-time downloads.
+race conditions from simultaneous first-time downloads. A `.download_complete`
+sentinel file is written only after the dataset is fully copied to the cache
+directory. If a download fails partway through (e.g. after exhausting all
+retries), the sentinel is absent and rerunning the sweep will resume the
+download rather than skipping it. In-progress files are staged in
+`/tmp/hf_download_<dataset>` and reused across runs, so HuggingFace will pick
+up from where it left off rather than starting over.
 
 For local runs, set `output.dataset_cache_dir` in `sweep_config.yaml` to a
 local path, or pass `--dataset_cache_dir /your/path` directly to

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -55,11 +55,19 @@ def parse_args():
 
 def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns):
     """Runs snapshot_download in a child process so it can be hard-killed on stall."""
+    import tempfile
     from huggingface_hub import snapshot_download
+
+    # keep .incomplete temp files on local disk; teamspace storage drops them
+    # before shutil.move can complete, causing FileNotFoundError
+    hf_cache = Path(tempfile.gettempdir()) / "hf_cache"
+    hf_cache.mkdir(parents=True, exist_ok=True)
+
     snapshot_download(
         repo_id=repo_id,
         repo_type=repo_type,
         local_dir=local_dir,
+        cache_dir=str(hf_cache),
         ignore_patterns=ignore_patterns,
     )
 

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -143,8 +143,9 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
 
     dataset_name = dataset_repo.split("/")[-1]
     cache_path = Path(cache_dir) / dataset_name
+    sentinel = cache_path / ".download_complete"
 
-    if cache_path.exists():
+    if sentinel.exists():
         print(f"Using cached dataset at {cache_path}", flush=True)
         (cache_path / "videos").mkdir(exist_ok=True)
         return cache_path
@@ -196,6 +197,7 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
     print(f"  Copying dataset from {tmp_dir} to {cache_path}...", flush=True)
     shutil.copytree(str(tmp_dir), str(cache_path), dirs_exist_ok=True)
     shutil.rmtree(str(tmp_dir), ignore_errors=True)
+    sentinel.touch()
 
     # LP asserts video_dir exists even when not using videos
     (cache_path / "videos").mkdir(exist_ok=True)

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -53,23 +53,24 @@ def parse_args():
     return p.parse_args()
 
 
-def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns):
-    """Runs snapshot_download in a child process so it can be hard-killed on stall."""
-    import tempfile
-    from huggingface_hub import snapshot_download
+def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns, tmp_dir):
+    """Runs snapshot_download in a child process so it can be hard-killed on stall.
 
-    # keep .incomplete temp files on local disk; teamspace storage drops them
-    # before shutil.move can complete, causing FileNotFoundError
-    hf_cache = Path(tempfile.gettempdir()) / "hf_cache"
-    hf_cache.mkdir(parents=True, exist_ok=True)
+    Downloads to local disk (tmp_dir) first to avoid .incomplete file issues on
+    network/distributed filesystems, then copies to the final local_dir.
+    """
+    import shutil
+    from huggingface_hub import snapshot_download
 
     snapshot_download(
         repo_id=repo_id,
         repo_type=repo_type,
-        local_dir=local_dir,
-        cache_dir=str(hf_cache),
+        local_dir=str(tmp_dir),
         ignore_patterns=ignore_patterns,
     )
+    print(f"  Copying dataset from {tmp_dir} to {local_dir}...")
+    shutil.copytree(str(tmp_dir), str(local_dir), dirs_exist_ok=True)
+    shutil.rmtree(str(tmp_dir), ignore_errors=True)
 
 
 def _watchdog(process, cache_path, stall_timeout, check_interval=30):
@@ -95,6 +96,37 @@ def _watchdog(process, cache_path, stall_timeout, check_interval=30):
             print(f"  No download progress for {stall_timeout}s — terminating stalled download.")
             process.terminate()
             return
+
+
+def _wait_for_filesystem_sync(cache_path, check_interval=15, timeout=300):
+    """Poll until the file count in cache_path stabilizes across two consecutive checks.
+
+    shutil.copytree can return before all writes are committed on distributed/network
+    filesystems. Polling is more reliable than a fixed sleep.
+    """
+    import time
+
+    def count_files():
+        try:
+            return sum(1 for f in cache_path.rglob("*") if f.is_file())
+        except Exception:
+            return 0
+
+    print("Waiting for dataset to become fully accessible on teamspace filesystem...")
+    prev_count = -1
+    deadline = time.time() + timeout
+
+    while True:
+        count = count_files()
+        if count > 0 and count == prev_count:
+            print(f"  Filesystem sync complete: {count} files accessible.")
+            return
+        prev_count = count
+        if time.time() >= deadline:
+            print(f"  Warning: filesystem may not be fully synced after {timeout}s; proceeding anyway.")
+            return
+        print(f"  {count} files accessible so far; rechecking in {check_interval}s...")
+        time.sleep(check_interval)
 
 
 def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
@@ -125,6 +157,10 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
 
     cache_path.mkdir(parents=True, exist_ok=True)
 
+    # download to local disk; .incomplete temp files on network storage cause FileNotFoundError
+    tmp_dir = Path("/tmp") / f"hf_download_{dataset_name}"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
     print(f"Downloading {dataset_repo} -> {cache_path}")
     print(f"  ignore_patterns: {ignore_patterns}")
 
@@ -135,12 +171,12 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
     for attempt in range(1, max_retries + 1):
         p = multiprocessing.Process(
             target=_snapshot_worker,
-            args=(dataset_repo, "dataset", str(cache_path), ignore_patterns),
+            args=(dataset_repo, "dataset", str(cache_path), ignore_patterns, str(tmp_dir)),
         )
         p.start()
 
         watcher = threading.Thread(
-            target=_watchdog, args=(p, cache_path, stall_timeout), daemon=True
+            target=_watchdog, args=(p, tmp_dir, stall_timeout), daemon=True
         )
         watcher.start()
         p.join()
@@ -157,6 +193,8 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
 
     # LP asserts video_dir exists even when not using videos
     (cache_path / "videos").mkdir(exist_ok=True)
+
+    _wait_for_filesystem_sync(cache_path)
 
     return cache_path
 

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -56,10 +56,9 @@ def parse_args():
 def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns, tmp_dir):
     """Runs snapshot_download in a child process so it can be hard-killed on stall.
 
-    Downloads to local disk (tmp_dir) first to avoid .incomplete file issues on
-    network/distributed filesystems, then copies to the final local_dir.
+    Downloads to local disk (tmp_dir) only. The copy to local_dir happens in the
+    parent process after this worker exits, so the watchdog does not kill it.
     """
-    import shutil
     from huggingface_hub import snapshot_download
 
     snapshot_download(
@@ -68,9 +67,6 @@ def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns, tmp_dir):
         local_dir=str(tmp_dir),
         ignore_patterns=ignore_patterns,
     )
-    print(f"  Copying dataset from {tmp_dir} to {local_dir}...", flush=True)
-    shutil.copytree(str(tmp_dir), str(local_dir), dirs_exist_ok=True)
-    shutil.rmtree(str(tmp_dir), ignore_errors=True)
 
 
 def _watchdog(process, cache_path, stall_timeout, check_interval=30):
@@ -187,7 +183,7 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
         p.join()
 
         if p.exitcode == 0:
-            break  # success
+            break  # watchdog has exited; safe to copy now
 
         msg = "stalled" if not p.is_alive() else f"exited with code {p.exitcode}"
         if attempt == max_retries:
@@ -195,6 +191,11 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
 
         print(f"  Download attempt {attempt}/{max_retries} {msg}; retrying in {retry_wait}s...", flush=True)
         time.sleep(retry_wait)
+
+    import shutil
+    print(f"  Copying dataset from {tmp_dir} to {cache_path}...", flush=True)
+    shutil.copytree(str(tmp_dir), str(cache_path), dirs_exist_ok=True)
+    shutil.rmtree(str(tmp_dir), ignore_errors=True)
 
     # LP asserts video_dir exists even when not using videos
     (cache_path / "videos").mkdir(exist_ok=True)

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -68,7 +68,7 @@ def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns, tmp_dir):
         local_dir=str(tmp_dir),
         ignore_patterns=ignore_patterns,
     )
-    print(f"  Copying dataset from {tmp_dir} to {local_dir}...")
+    print(f"  Copying dataset from {tmp_dir} to {local_dir}...", flush=True)
     shutil.copytree(str(tmp_dir), str(local_dir), dirs_exist_ok=True)
     shutil.rmtree(str(tmp_dir), ignore_errors=True)
 
@@ -93,7 +93,7 @@ def _watchdog(process, cache_path, stall_timeout, check_interval=30):
             last_size = size
             last_progress = time.time()
         elif time.time() - last_progress > stall_timeout:
-            print(f"  No download progress for {stall_timeout}s — terminating stalled download.")
+            print(f"  No download progress for {stall_timeout}s — terminating stalled download.", flush=True)
             process.terminate()
             return
 
@@ -112,20 +112,25 @@ def _wait_for_filesystem_sync(cache_path, check_interval=15, timeout=300):
         except Exception:
             return 0
 
-    print("Waiting for dataset to become fully accessible on teamspace filesystem...")
+    print("Waiting for dataset to become fully accessible on teamspace filesystem...", flush=True)
     prev_count = -1
-    deadline = time.time() + timeout
+    start = time.time()
+    deadline = start + timeout
 
     while True:
         count = count_files()
+        elapsed = int(time.time() - start)
         if count > 0 and count == prev_count:
-            print(f"  Filesystem sync complete: {count} files accessible.")
+            print(f"  Filesystem sync complete after {elapsed}s: {count} files accessible.", flush=True)
             return
         prev_count = count
         if time.time() >= deadline:
-            print(f"  Warning: filesystem may not be fully synced after {timeout}s; proceeding anyway.")
+            print(
+                f"  Warning: filesystem may not be fully synced after {timeout}s; proceeding anyway.",
+                flush=True,
+            )
             return
-        print(f"  {count} files accessible so far; rechecking in {check_interval}s...")
+        print(f"  [{elapsed}s elapsed] {count} files accessible so far; rechecking in {check_interval}s...", flush=True)
         time.sleep(check_interval)
 
 
@@ -144,7 +149,7 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
     cache_path = Path(cache_dir) / dataset_name
 
     if cache_path.exists():
-        print(f"Using cached dataset at {cache_path}")
+        print(f"Using cached dataset at {cache_path}", flush=True)
         (cache_path / "videos").mkdir(exist_ok=True)
         return cache_path
 
@@ -161,8 +166,8 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
     tmp_dir = Path("/tmp") / f"hf_download_{dataset_name}"
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
-    print(f"Downloading {dataset_repo} -> {cache_path}")
-    print(f"  ignore_patterns: {ignore_patterns}")
+    print(f"Downloading {dataset_repo} -> {cache_path}", flush=True)
+    print(f"  ignore_patterns: {ignore_patterns}", flush=True)
 
     max_retries = 5
     stall_timeout = 5 * 60  # kill if no bytes received for 5 minutes
@@ -188,7 +193,7 @@ def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
         if attempt == max_retries:
             raise RuntimeError(f"Failed to download {dataset_repo} after {max_retries} attempts ({msg})")
 
-        print(f"  Download attempt {attempt}/{max_retries} {msg}; retrying in {retry_wait}s...")
+        print(f"  Download attempt {attempt}/{max_retries} {msg}; retrying in {retry_wait}s...", flush=True)
         time.sleep(retry_wait)
 
     # LP asserts video_dir exists even when not using videos
@@ -243,7 +248,7 @@ def main():
         ]
 
     cmd = ["litpose", "train", config_file, "--output_dir", args.output_dir, "--overrides"] + overrides
-    print("Running:", " ".join(cmd))
+    print("Running:", " ".join(cmd), flush=True)
     subprocess.run(cmd, check=True)
 
     # -------------------------------------------------------------------------
@@ -253,8 +258,8 @@ def main():
     for ckpt in Path(args.output_dir).rglob("*.ckpt"):
         ckpt.unlink()
         n_deleted += 1
-    print(f"Deleted {n_deleted} checkpoint file(s)")
-    print(f"Done. Results at {args.output_dir}")
+    print(f"Deleted {n_deleted} checkpoint file(s)", flush=True)
+    print(f"Done. Results at {args.output_dir}", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  HuggingFace Hub's snapshot_download creates .incomplete temp files under
  {local_dir}/.cache/huggingface/download/, which the teamspace filesystem drops before they can be
  moved to their final destination, causing FileNotFoundError. This PR fixes three related issues:

  - Two-phase download: files are now downloaded to local /tmp first, then copied to teamspace once
  complete, so .incomplete files never land on the network filesystem.
  - Filesystem sync check: after copying, a polling loop waits until the visible file count
  stabilizes across two consecutive 15-second checks rather than using a fixed sleep, which was too
  short and non-deterministic.
  - Watchdog now monitors the right directory: the stall detector is pointed at the local temp dir
  where actual download activity happens.