### PR TITLE
download zips from huggingface

### DIFF
--- a/scripts/hyper-sweep/README.md
+++ b/scripts/hyper-sweep/README.md
@@ -6,16 +6,23 @@ Scripts for running parallel Lightning Pose training sweeps, either on
 ## How it works
 
 `run_sweep.py` builds the cartesian product of all sweep dimensions defined in
-`sweep_config.yaml`. Before launching any jobs, it pre-downloads each unique
-dataset into a shared teamspace cache — so the download happens exactly once,
-regardless of how many jobs share that dataset. It then launches one Lightning AI
-Job per combination. Each job runs `run_single_job.py`, which:
+`sweep_config.yaml` and launches one Lightning AI Job per combination. Each job
+runs `run_single_job.py`, which:
 
-1. Uses the pre-cached dataset on teamspace (skips downloading if already present)
+1. Downloads a single zip archive of the dataset from HuggingFace and extracts
+   it to local (ephemeral) disk on the studio the job is running in
 2. Calls `litpose train` with the appropriate config and overrides
 3. Deletes model weights (`.ckpt`) to save storage
 
 Results are written to teamspace storage and persist after each job ends.
+
+Every job downloads its own copy of the dataset independently — there is no
+shared cache. This trades a small amount of duplicate downloading (each job
+fetches the same zip) for reliability: a single-file download is fast and
+immune to the HuggingFace rate limits and distributed-filesystem sync issues
+that come from downloading thousands of individual files onto shared teamspace
+storage. See [Dataset zip archives](#dataset-zip-archives) for how to prepare
+the zip file each dataset needs.
 
 ## Output structure
 
@@ -40,15 +47,16 @@ the studio is a self-contained environment.
 
 ### Teamspace storage setup
 
-Sweep results and cached datasets are written to Lightning's managed teamspace
-storage. Create the required folders once before running any sweeps:
+Sweep results are written to Lightning's managed teamspace storage. Create the
+required folder once before running any sweeps:
 
 1. In your teamspace, click the **Drive** tab (next to Studios)
-2. Click **New Folder** and create a folder named `datasets`
-3. Click **New Folder** again and create a folder named `sweep-results`
+2. Click **New Folder** and create a folder named `sweep-results`
 
-These names match the default paths in `sweep_config.yaml`, so no config edits
-are needed.
+This name matches the default `output.base_dir` in `sweep_config.yaml`, so no
+config edits are needed. Datasets are no longer cached on teamspace storage —
+each job downloads its own copy to local disk (see
+[Dataset zip archives](#dataset-zip-archives)).
 
 ### From within a studio
 
@@ -123,32 +131,49 @@ Key fields:
 | `sweep.predict_vids_after_training` | Run video prediction after training |
 | `lightning.machine` | GPU type (`T4_SMALL`, `T4`, `A10G`, `A100`) |
 | `output.base_dir` | Root path for results on teamspace storage |
+| `output.local_data_dir` | Local (ephemeral) dir each job extracts its dataset(s) into |
 | `debug` | `true` for a 3-epoch smoke test |
 
-### Dataset caching
+## Dataset zip archives
 
-Downloaded datasets are cached in `output.dataset_cache_dir` (default:
-`/teamspace/lightning_storage/datasets`), avoiding HuggingFace rate limits and
-race conditions from simultaneous first-time downloads. A `.download_complete`
-sentinel file is written only after the dataset is fully copied to the cache
-directory. If a download fails partway through (e.g. after exhausting all
-retries), the sentinel is absent and rerunning the sweep will resume the
-download rather than skipping it. In-progress files are staged in
-`/tmp/hf_download_<dataset>` and reused across runs, so HuggingFace will pick
-up from where it left off rather than starting over.
+Each job downloads a single zip file, named `<dataset_name>.zip` (e.g.
+`mirror-mouse-fused.zip`), from the root of the dataset's HuggingFace repo. It
+is extracted to `<output.local_data_dir>/<dataset_name>` (default
+`/tmp/lp_data/<dataset_name>`) on the studio the job is running in — local
+disk, not teamspace storage. Because extraction is namespaced by dataset name,
+multiple datasets can coexist under the same `local_data_dir` without
+colliding (useful for local runs that sweep over several datasets). No cleanup
+of the extracted data is needed on Lightning AI: each Job runs in its own
+fresh container, so the disk is reclaimed automatically when the job ends.
 
-For local runs, set `output.dataset_cache_dir` in `sweep_config.yaml` to a
-local path, or pass `--dataset_cache_dir /your/path` directly to
-`run_single_job.py`.
+**This zip file is not created automatically** — it must be prepared and
+uploaded to each dataset's HuggingFace repo once, before running a sweep
+against that dataset. Since these published datasets are largely static, this
+is a one-time (or rare) step per dataset, not something the sweep pipeline
+does for you.
 
-### Video download gating
+To prepare it, zip the *contents* of the dataset directory (not the directory
+itself, so the zip has no wrapping folder — files like
+`config_<dataset>.yaml` should sit at the top level of the archive):
 
-To avoid downloading large video files unnecessarily:
+```bash
+cd /path/to/local/copy/of/mirror-mouse-fused
+zip -r mirror-mouse-fused.zip .
+```
 
-- `videos/` (InD) — only downloaded when `losses_to_use` contains at least one
-  unsupervised loss (i.e., any non-empty entry in the list)
-- `videos_test/` (OOD) — only downloaded when `predict_vids_after_training: true`
-- `videos-for-each-labeled-frame/` — never downloaded (used for post-hoc smoothing only)
+Then upload it to the dataset's HuggingFace repo, e.g. with the
+`huggingface_hub` Python API:
+
+```python
+from huggingface_hub import upload_file
+
+upload_file(
+    path_or_fileobj="mirror-mouse-fused.zip",
+    path_in_repo="mirror-mouse-fused.zip",
+    repo_id="paninski-lab/mirror-mouse-fused",
+    repo_type="dataset",
+)
+```
 
 ## Running locally (no Lightning AI)
 

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -1,9 +1,9 @@
 """
 Worker script: runs inside a single Lightning AI job.
 
-Downloads a dataset from HuggingFace (or uses a teamspace cache), trains one
-Lightning Pose model via `litpose train`, and deletes model weights.
-Results land in --output_dir (a path on teamspace storage).
+Downloads a dataset's zip archive from HuggingFace, extracts it to local (ephemeral)
+studio disk, trains one Lightning Pose model via `litpose train`, and deletes model
+weights. Results land in --output_dir (a path on teamspace storage).
 
 Can also be called directly for local sweeps (no Lightning AI required):
     python run_single_job.py --dataset_repo paninski-lab/mirror-mouse-fused \\
@@ -19,7 +19,7 @@ from pathlib import Path
 # must be set before huggingface_hub is imported
 os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
 
-DEFAULT_DATASET_CACHE_DIR = "/teamspace/lightning_storage/datasets"
+DEFAULT_LOCAL_DATA_DIR = "/tmp/lp_data"
 
 
 def parse_args():
@@ -29,8 +29,9 @@ def parse_args():
         help="HuggingFace repo ID, e.g. paninski-lab/mirror-mouse-fused",
     )
     p.add_argument(
-        "--dataset_cache_dir", default=DEFAULT_DATASET_CACHE_DIR,
-        help="Directory where datasets are cached; set to a local path when running outside Lightning AI",
+        "--local_data_dir", default=DEFAULT_LOCAL_DATA_DIR,
+        help="Local (ephemeral) directory to download and extract dataset zips into; "
+             "each dataset gets its own <local_data_dir>/<dataset_name> subdirectory",
     )
     p.add_argument("--backbone", required=True)
     p.add_argument("--train_frames", type=int, required=True)
@@ -42,169 +43,71 @@ def parse_args():
     p.add_argument("--model_type", default="heatmap")
     p.add_argument("--output_dir", required=True, help="Absolute path for training outputs")
     p.add_argument(
-        "--download_videos", action="store_true",
-        help="Download InD videos/ directory (required for unsupervised losses)",
-    )
-    p.add_argument(
         "--predict_vids", action="store_true",
-        help="Run video prediction after training; also downloads videos_test/",
+        help="Run video prediction after training",
     )
     p.add_argument("--debug", action="store_true", help="Short smoke-test run (3 epochs)")
     return p.parse_args()
 
 
-def _snapshot_worker(repo_id, repo_type, local_dir, ignore_patterns, tmp_dir):
-    """Runs snapshot_download in a child process so it can be hard-killed on stall.
+def get_dataset(dataset_repo, local_data_dir):
+    """Download a dataset's zip archive from HuggingFace and extract it to local disk.
 
-    Downloads to local disk (tmp_dir) only. The copy to local_dir happens in the
-    parent process after this worker exits, so the watchdog does not kill it.
-    """
-    from huggingface_hub import snapshot_download
+    Every job downloads and extracts its own copy fresh, rather than sharing a cache
+    on teamspace storage. A single zip file is small enough that this is fast and
+    sidesteps the rate-limit and distributed-filesystem sync issues that came from
+    downloading thousands of individual files via snapshot_download onto network
+    storage.
 
-    snapshot_download(
-        repo_id=repo_id,
-        repo_type=repo_type,
-        local_dir=str(tmp_dir),
-        ignore_patterns=ignore_patterns,
-    )
-
-
-def _watchdog(process, cache_path, stall_timeout, check_interval=30):
-    """Monitors download progress; terminates process if no bytes land for stall_timeout seconds."""
-    import time
-
-    def dir_size():
-        try:
-            return sum(f.stat().st_size for f in Path(cache_path).rglob("*") if f.is_file())
-        except Exception:
-            return 0
-
-    last_size = dir_size()
-    last_progress = time.time()
-
-    while process.is_alive():
-        time.sleep(check_interval)
-        size = dir_size()
-        if size > last_size:
-            last_size = size
-            last_progress = time.time()
-        elif time.time() - last_progress > stall_timeout:
-            print(f"  No download progress for {stall_timeout}s — terminating stalled download.", flush=True)
-            process.terminate()
-            return
-
-
-def _wait_for_filesystem_sync(cache_path, check_interval=15, timeout=300):
-    """Poll until the file count in cache_path stabilizes across two consecutive checks.
-
-    shutil.copytree can return before all writes are committed on distributed/network
-    filesystems. Polling is more reliable than a fixed sleep.
+    The dataset is extracted to <local_data_dir>/<dataset_name>, so multiple datasets
+    can coexist under the same local_data_dir without colliding.
     """
     import time
+    import zipfile
 
-    def count_files():
-        try:
-            return sum(1 for f in cache_path.rglob("*") if f.is_file())
-        except Exception:
-            return 0
-
-    print("Waiting for dataset to become fully accessible on teamspace filesystem...", flush=True)
-    prev_count = -1
-    start = time.time()
-    deadline = start + timeout
-
-    while True:
-        count = count_files()
-        elapsed = int(time.time() - start)
-        if count > 0 and count == prev_count:
-            print(f"  Filesystem sync complete after {elapsed}s: {count} files accessible.", flush=True)
-            return
-        prev_count = count
-        if time.time() >= deadline:
-            print(
-                f"  Warning: filesystem may not be fully synced after {timeout}s; proceeding anyway.",
-                flush=True,
-            )
-            return
-        print(f"  [{elapsed}s elapsed] {count} files accessible so far; rechecking in {check_interval}s...", flush=True)
-        time.sleep(check_interval)
-
-
-def get_dataset(dataset_repo, cache_dir, download_videos, predict_vids):
-    """Return path to dataset, downloading from HuggingFace only if not cached.
-
-    Runs the download in a subprocess watched by a progress monitor. If no bytes
-    land for stall_timeout seconds the download is killed and retried, allowing
-    arbitrarily large/slow downloads while still catching rate-limit hangs.
-    """
-    import multiprocessing
-    import threading
-    import time
+    from huggingface_hub import hf_hub_download
 
     dataset_name = dataset_repo.split("/")[-1]
-    cache_path = Path(cache_dir) / dataset_name
-    sentinel = cache_path / ".download_complete"
+    zip_filename = f"{dataset_name}.zip"
+    local_data_dir = Path(local_data_dir)
+    extract_dir = local_data_dir / dataset_name
 
-    if sentinel.exists():
-        print(f"Using cached dataset at {cache_path}", flush=True)
-        (cache_path / "videos").mkdir(exist_ok=True)
-        return cache_path
-
-    # videos-for-each-labeled-frame is only needed for post-hoc smoothing, never for training
-    ignore_patterns = ["videos-for-each-labeled-frame/*"]
-    if not download_videos:
-        ignore_patterns.append("videos/*")
-    if not predict_vids:
-        ignore_patterns.append("videos_test/*")
-
-    cache_path.mkdir(parents=True, exist_ok=True)
-
-    # download to local disk; .incomplete temp files on network storage cause FileNotFoundError
-    tmp_dir = Path("/tmp") / f"hf_download_{dataset_name}"
-    tmp_dir.mkdir(parents=True, exist_ok=True)
-
-    print(f"Downloading {dataset_repo} -> {cache_path}", flush=True)
-    print(f"  ignore_patterns: {ignore_patterns}", flush=True)
-
-    max_retries = 5
-    stall_timeout = 5 * 60  # kill if no bytes received for 5 minutes
-    retry_wait = 90          # pause before retrying to let rate limit window reset
-
+    print(f"Downloading {zip_filename} from {dataset_repo}...", flush=True)
+    max_retries = 3
+    retry_wait = 30
+    zip_path = None
     for attempt in range(1, max_retries + 1):
-        p = multiprocessing.Process(
-            target=_snapshot_worker,
-            args=(dataset_repo, "dataset", str(cache_path), ignore_patterns, str(tmp_dir)),
-        )
-        p.start()
+        try:
+            zip_path = hf_hub_download(
+                repo_id=dataset_repo,
+                repo_type="dataset",
+                filename=zip_filename,
+                local_dir=str(local_data_dir),
+            )
+            break
+        except Exception as e:
+            if attempt == max_retries:
+                raise RuntimeError(
+                    f"Failed to download {zip_filename} from {dataset_repo} "
+                    f"after {max_retries} attempts"
+                ) from e
+            print(
+                f"  Download attempt {attempt}/{max_retries} failed ({e}); "
+                f"retrying in {retry_wait}s...",
+                flush=True,
+            )
+            time.sleep(retry_wait)
 
-        watcher = threading.Thread(
-            target=_watchdog, args=(p, tmp_dir, stall_timeout), daemon=True
-        )
-        watcher.start()
-        p.join()
+    print(f"Extracting {zip_path} -> {extract_dir}", flush=True)
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract_dir)
+    Path(zip_path).unlink()
 
-        if p.exitcode == 0:
-            break  # watchdog has exited; safe to copy now
+    # LP asserts video_dir exists even for datasets with no video files
+    (extract_dir / "videos").mkdir(exist_ok=True)
 
-        msg = "stalled" if not p.is_alive() else f"exited with code {p.exitcode}"
-        if attempt == max_retries:
-            raise RuntimeError(f"Failed to download {dataset_repo} after {max_retries} attempts ({msg})")
-
-        print(f"  Download attempt {attempt}/{max_retries} {msg}; retrying in {retry_wait}s...", flush=True)
-        time.sleep(retry_wait)
-
-    import shutil
-    print(f"  Copying dataset from {tmp_dir} to {cache_path}...", flush=True)
-    shutil.copytree(str(tmp_dir), str(cache_path), dirs_exist_ok=True)
-    shutil.rmtree(str(tmp_dir), ignore_errors=True)
-    sentinel.touch()
-
-    # LP asserts video_dir exists even when not using videos
-    (cache_path / "videos").mkdir(exist_ok=True)
-
-    _wait_for_filesystem_sync(cache_path)
-
-    return cache_path
+    return extract_dir
 
 
 def main():
@@ -212,9 +115,9 @@ def main():
     dataset_name = args.dataset_repo.split("/")[-1]
 
     # -------------------------------------------------------------------------
-    # 1. Get dataset (from cache or HuggingFace)
+    # 1. Get dataset (download + extract zip from HuggingFace)
     # -------------------------------------------------------------------------
-    data_dir = get_dataset(args.dataset_repo, args.dataset_cache_dir, args.download_videos, args.predict_vids)
+    data_dir = get_dataset(args.dataset_repo, args.local_data_dir)
 
     # -------------------------------------------------------------------------
     # 2. Build and run litpose train

--- a/scripts/hyper-sweep/run_single_job.py
+++ b/scripts/hyper-sweep/run_single_job.py
@@ -132,6 +132,7 @@ def main():
 
     overrides = [
         f"data.data_dir={data_dir}",
+        f"data.video_dir={data_dir}/videos",
         f"model.model_type={args.model_type}",
         f"model.backbone={args.backbone}",
         f"model.losses_to_use={losses_hydra}",

--- a/scripts/hyper-sweep/run_sweep.py
+++ b/scripts/hyper-sweep/run_sweep.py
@@ -68,12 +68,11 @@ def make_worker_command(combo, cfg, worker_script) -> str:
         cfg["output"]["base_dir"], dataset_repo, backbone, train_frames, seed, losses
     )
     predict_vids = cfg["sweep"].get("predict_vids_after_training", False)
-    download_videos = len(losses) > 0
 
     parts = [
         "python", str(worker_script),
         f"--dataset_repo={dataset_repo}",
-        f"--dataset_cache_dir={cfg['output'].get('dataset_cache_dir', '/teamspace/lightning_storage/datasets')}",
+        f"--local_data_dir={cfg['output'].get('local_data_dir', '/tmp/lp_data')}",
         f"--backbone={backbone}",
         f"--train_frames={train_frames}",
         f"--seed={seed}",
@@ -81,8 +80,6 @@ def make_worker_command(combo, cfg, worker_script) -> str:
         f"--model_type={cfg['sweep'].get('model_type', 'heatmap')}",
         f"--output_dir={out_dir}",
     ]
-    if download_videos:
-        parts.append("--download_videos")
     if predict_vids:
         parts.append("--predict_vids")
     if cfg.get("debug", False):
@@ -131,15 +128,6 @@ def main():
             cmd = make_worker_command(combo, cfg, worker_script)
             print(f"\n{name}:\n  {cmd}")
         return
-
-    # pre-download each unique dataset before launching jobs to avoid a race
-    # condition where many jobs simultaneously attempt to populate an empty cache
-    from run_single_job import get_dataset
-    cache_dir = cfg["output"].get("dataset_cache_dir", "/teamspace/lightning_storage/datasets")
-    download_videos = any(len(l) > 0 for l in sweep.get("losses_to_use", [[]]))
-    predict_vids = sweep.get("predict_vids_after_training", False)
-    for dataset_repo in set(sweep["datasets"]):
-        get_dataset(dataset_repo, cache_dir, download_videos, predict_vids)
 
     from lightning_sdk import Job, Machine, Studio
 

--- a/scripts/hyper-sweep/sweep_config.yaml
+++ b/scripts/hyper-sweep/sweep_config.yaml
@@ -6,8 +6,10 @@ sweep:
   # HuggingFace repo IDs (org/dataset-name)
   datasets:
     - paninski-lab/mirror-mouse-fused
-    # - paninski-lab/mirror-fish
+    # - paninski-lab/facemap
     # - paninski-lab/crim13
+    # - paninski-lab/mirror-fish
+    # - paninski-lab/marmoset3k
 
   backbones:
     - resnet50_animal_ap10k
@@ -34,7 +36,7 @@ sweep:
     # - [temporal]
     # - [pca_singleview, temporal]
 
-  # heatmap | context | regression
+  # heatmap | heatmap_mhcrnn | heatmap_multiview_transformer
   model_type: heatmap
 
   # Run LP video prediction after training.
@@ -54,8 +56,11 @@ lightning:
 output:
   # Root directory on teamspace storage; <dataset-name> is appended automatically
   base_dir: /teamspace/lightning_storage/sweep-results
-  # Where downloaded datasets are cached; override for local runs
-  dataset_cache_dir: /teamspace/lightning_storage/datasets
+  # Local (ephemeral) directory each job downloads and extracts its dataset zip into;
+  # each dataset gets its own <local_data_dir>/<dataset_name> subdirectory, so multiple
+  # datasets can coexist here (e.g. for local runs). Each dataset's zip is expected to
+  # be named <dataset_name>.zip in the root of its HuggingFace repo.
+  local_data_dir: /tmp/lp_data
 
 # =============================================================================
 # Misc


### PR DESCRIPTION
**Summary**

  Replace the shared-teamspace-cache dataset download in `scripts/hyper-sweep/` with a per-job download of a
  single zip file from HuggingFace, extracted to local (ephemeral) disk on the studio each job runs on.

  - Downloading thousands of individual files via `snapshot_download` onto Lightning AI's distributed
  teamspace filesystem was slow, subject to HuggingFace rate limits, and failed in several distinct ways
  (hangs with many files, files not syncing, zip downloads/extracts hanging on the network FS).
  `run_single_job.py::get_dataset()` had grown a subprocess + watchdog to hard-kill stalled downloads, a
  retry loop, and a polling loop to work around shutil.copytree returning before writes landed on the
  network FS.
  - Now each job downloads one `<dataset_name>.zip` from the root of the dataset's HuggingFace repo
  (hf_hub_download, with a light 3-attempt retry) and extracts it to `<local_data_dir>/<dataset_name>` on
  local disk, namespaced by dataset name so multiple datasets can coexist under the same `local_data_dir`
  (useful for local sweeps). All of the watchdog/retry/filesystem-sync machinery is gone.
  - `run_sweep.py` no longer pre-downloads each unique dataset into a shared cache before launching jobs —
  there's no shared cache left to race on, so every job just downloads its own copy independently.
  - `--download_videos` is gone: since the zip always contains the full dataset, there's nothing left to
  gate.

**Trade-offs**

  - Uploading a new zip to a dataset repo requires re-uploading the whole archive rather than a single
  changed file. Acceptable since these published datasets are largely static.
  - Running many jobs against the same dataset means downloading that dataset's zip many times instead of
  once. Acceptable since each download is now a single fast file rather than thousands of small ones.
  - The zip is not created automatically — each dataset's `<dataset_name>.zip` must be prepared and uploaded
  to HuggingFace once, documented in the new "Dataset zip archives" README section.
