### PR TITLE
Add multiview accuracy/speed results to mixed_precision.rst,

### DIFF
--- a/docs/source/user_guide_advanced/mixed_precision.rst
+++ b/docs/source/user_guide_advanced/mixed_precision.rst
@@ -18,9 +18,12 @@ itself.
   **it is safe to run inference at a different precision than the model was trained at** --
   deltas are under 0.01px in every case tested.
 - **Speed:** reduced precision speeds up the model's forward pass substantially at larger batch
-  sizes (up to ~3x for ResNet50, ~4.7x for ViT-S at batch 64 on an A100). It does **not**
-  measurably speed up end-to-end ``litpose predict`` on a T4 GPU -- video preprocessing (DALI)
-  dominates total runtime there, not the forward pass.
+  sizes (up to ~3x for ResNet50, ~4.7x for ViT-S at batch 64 on an A100). End-to-end
+  ``litpose predict`` speed depends on GPU generation and dataset: on a **T4** GPU (no native
+  BF16 tensor cores), **FP16 gives large, reliable end-to-end speedups (1.4-2.5x)** while BF16
+  is consistently *slower* than FP32. On an **A100** (native support for both), FP16 and BF16
+  track each other closely, and the end-to-end speedup ranges from roughly flat (single-view
+  ResNet50, likely decode-bound) to a strong 1.6x (2-view multi-view model).
 
 This page will grow over time as we benchmark more architectures, datasets, and hardware.
 
@@ -55,7 +58,7 @@ accuracy, and does the precision used *during inference* (independent of trainin
 affect accuracy? Single-view results below use ``resnet50_animal_ap10k``; multi-view results
 use ``heatmap_multiview_transformer`` with a ``vits_dinov2`` backbone, since the single-view
 architecture has no cross-view attention mechanism. Both use 100 train frames and report mean
-pixel error ± SEM (standard deviation across 3 seeds, divided by :math:`\sqrt{3}`) -- for
+pixel error ± SEM (3 seeds) -- for
 multi-view datasets, error is averaged across camera views within each seed before computing
 the across-seed mean/SEM.
 
@@ -253,44 +256,76 @@ view multiplies the effective batch fed to the backbone:
      - 4.56x
      - 4.55x
 
-**Important caveat -- applies to both single- and multi-view:** these tables measure the
-GPU forward pass in isolation. End-to-end video inference (via ``litpose predict``) did not
-show a measurable speedup from reduced precision for either single-view models (T4 GPU) or
-multi-view models (A100 GPU, see the end-to-end table below) -- despite the multi-view
-forward pass accounting for the large majority of end-to-end wall time in a separate
-profiling pass. This is a genuine open question we haven't resolved yet: why an isolated
-forward-pass speedup this large doesn't show up end-to-end. We'll expand this section if and
-when we track down the discrepancy.
+**End-to-end speed.** The forward-pass numbers above isolate GPU compute; real-world
+``litpose predict`` speed also includes video decoding/preprocessing (DALI) and
+postprocessing, so end-to-end speedups differ from the isolated forward-pass numbers. We
+benchmarked end-to-end speed on both a T4 and an A100 GPU, 7 repeats per precision.
+Single-view uses ResNet50 on one 469-frame video; multi-view uses
+``heatmap_multiview_transformer`` + ``vits_dinov2`` on both multi-view datasets. DALI
+``sequence_length`` is 64 throughout, except fly-anipose on T4, which used 16 -- forced by a
+GPU memory limit when decoding 6 simultaneous camera views at the default length.
 
-**Multi-view end-to-end speed.** The forward-pass benchmark above uses single-view
-architectures; multi-view models (``heatmap_multiview_transformer`` + ``vits_dinov2``)
-process every camera view simultaneously each forward pass, so we also measured end-to-end
-``litpose predict`` speed directly, 7 repeats per precision, on an A100-SXM4-80GB, 256x256
-input per view. Both datasets use the same DALI ``sequence_length`` (64), so the two rows
-below are directly comparable to each other, not just within each row:
-
-.. list-table:: End-to-end inference speed, multi-view models (A100 GPU, seq_len=64)
-   :widths: 25 20 20 20
+.. list-table:: End-to-end inference speed, single-view (ResNet50, 1 view, 256px input, seq_len=64)
+   :widths: 20 20 20 20
    :header-rows: 1
 
-   * - Dataset
+   * - GPU
      - FP32
      - FP16
      - BF16
-   * - mirror-mouse-separate (2 views)
-     - 79.6s
-     - 79.8s (+0.2%)
-     - 80.0s (+0.5%)
-   * - fly-anipose (6 views)
-     - 27.2s
-     - 27.0s (-0.6%)
-     - 27.1s (-0.1%)
+   * - T4
+     - 165.2s
+     - 110.0s (1.50x)
+     - 352.2s (0.47x -- slower)
+   * - A100
+     - 52.2s
+     - 51.8s (1.01x)
+     - 51.9s (1.01x)
 
-Both datasets are flat across precisions (well under 1% spread) -- the same
-DALI/video-I/O-bound pattern seen in the single-view benchmarks. Notably, on an earlier T4
-run at a smaller, memory-constrained sequence length (16), fly-anipose showed a small but
-real slowdown at BF16 (+5.2%); that slowdown disappears here at sequence length 64 on an
-A100, consistent with our hypothesis that it was a batch-size artifact (the forward-pass
-microbenchmark above shows reduced precision is actually slower than FP32 at small batch
-sizes, crossing over to a speedup only around batch 8) rather than a fundamental property of
-multi-view models.
+.. list-table:: End-to-end inference speed, multi-view models (256px input per view)
+   :widths: 30 15 20 20 20
+   :header-rows: 1
+
+   * - Dataset
+     - GPU
+     - FP32
+     - FP16
+     - BF16
+   * - mirror-mouse-separate (2 views, seq_len=64)
+     - T4
+     - 330.2s
+     - 134.6s (2.45x)
+     - 468.4s (0.70x -- slower)
+   * - mirror-mouse-separate (2 views, seq_len=64)
+     - A100
+     - 76.8s
+     - 48.6s (1.58x)
+     - 48.7s (1.58x)
+   * - fly-anipose (6 views, seq_len=16)
+     - T4
+     - 50.9s
+     - 35.4s (1.44x)
+     - 69.2s (0.74x -- slower)
+   * - fly-anipose (6 views, seq_len=64)
+     - A100
+     - 24.7s
+     - 22.8s (1.08x)
+     - 21.8s (1.13x)
+
+Two patterns are consistent across every benchmark above. First, **GPU generation matters as
+much as dataset**: the T4 (Turing generation) lacks native BF16 tensor-core support --
+that hardware support was introduced with Ampere, e.g. the A100 -- so BF16 is consistently
+*slower* than FP32 end-to-end on every T4 benchmark here, while FP16, which T4 does support
+natively, gives substantial, reliable speedups (1.4-2.5x). On the A100, FP16 and BF16 perform
+similarly to each other, as expected from equivalent hardware support. Second, even
+restricting to the A100, **the size of the end-to-end speedup is dataset-dependent**:
+single-view ResNet50 is essentially flat, consistent with video decoding dominating wall time
+for that benchmark, while the multi-view models see real speedups that vary by dataset --
+1.58x for the 2-view mirror-mouse-separate model, a more modest 1.08-1.13x for the 6-view
+fly-anipose model, which decodes more simultaneous video streams and where DALI likely
+occupies a larger share of total time. End-to-end speedups are smaller than the isolated
+forward-pass numbers above in every case, which is expected: end-to-end time also includes
+DALI decode and postprocessing work that does not get faster with reduced precision.
+fly-anipose's T4 row used a smaller sequence length (16, forced by the 6-view memory limit)
+than its A100 row (64), so that comparison is valid within each GPU but not directly
+comparable across GPUs to the same degree as mirror-mouse-separate.

--- a/docs/source/user_guide_advanced/mixed_precision.rst
+++ b/docs/source/user_guide_advanced/mixed_precision.rst
@@ -52,8 +52,12 @@ Results: accuracy
 
 Two separate questions matter here: does the precision used *during training* affect
 accuracy, and does the precision used *during inference* (independent of training precision)
-affect accuracy? Both experiments below use ``resnet50_animal_ap10k``, 100 train frames, and
-report mean pixel error ± SEM (standard deviation across 3 seeds, divided by :math:`\sqrt{3}`).
+affect accuracy? Single-view results below use ``resnet50_animal_ap10k``; multi-view results
+use ``heatmap_multiview_transformer`` with a ``vits_dinov2`` backbone, since the single-view
+architecture has no cross-view attention mechanism. Both use 100 train frames and report mean
+pixel error ± SEM (standard deviation across 3 seeds, divided by :math:`\sqrt{3}`) -- for
+multi-view datasets, error is averaged across camera views within each seed before computing
+the across-seed mean/SEM.
 
 **Training precision.** Training a model at reduced precision and evaluating at that same
 precision:
@@ -66,6 +70,10 @@ precision:
      - FP32 train / eval
      - FP16 train / eval
      - BF16 train / eval
+   * - **Single-view**
+     -
+     -
+     -
    * - `mirror-mouse-fused <https://huggingface.co/datasets/paninski-lab/mirror-mouse-fused>`_
      - 7.11 ± 0.11 px
      - 6.40 ± 0.23 px
@@ -86,13 +94,26 @@ precision:
      - 37.41 ± 0.61 px
      - 37.27 ± 0.12 px
      - 37.25 ± 0.75 px
+   * - **Multi-view**
+     -
+     -
+     -
+   * - `mirror-mouse-separate <https://huggingface.co/datasets/paninski-lab/mirror-mouse-separate>`_ (2 views)
+     - 5.23 ± 0.65 px
+     - 5.23 ± 0.36 px
+     - 5.03 ± 0.37 px
+   * - `fly-anipose <https://huggingface.co/datasets/paninski-lab/fly-anipose>`_ (6 views)
+     - 9.34 ± 0.02 px
+     - 9.24 ± 0.09 px
+     - 9.29 ± 0.10 px
 
 Differences between precisions are small relative to the SEM in most cases -- e.g. facemap's
 FP16 mean is nominally higher than FP32, but both are within ~1 SEM of each other. The
-clearest gap is mirror-mouse-fused, where FP16 training is about 0.7px lower than FP32; even
-there the effect is modest. Overall: mixed-precision training does not cause a systematic
-accuracy loss across the datasets tested, though the direction and size of any effect is
-dataset-dependent.
+clearest single-view gap is mirror-mouse-fused, where FP16 training is about 0.7px lower than
+FP32; even there the effect is modest. The multi-view datasets show an even cleaner null
+result -- no dataset's FP16/BF16 mean clears its own FP32 SEM bar. Overall: mixed-precision
+training does not cause a systematic accuracy loss across any dataset tested, single- or
+multi-view, though the direction and size of any effect is dataset-dependent.
 
 **Inference precision.** Independent of training precision, changing the precision used
 *only at inference time* (model trained at FP32, evaluated at FP16/BF16) has essentially no
@@ -106,6 +127,10 @@ effect on accuracy, across every dataset tested:
      - FP32 eval
      - FP16 eval
      - BF16 eval
+   * - **Single-view**
+     -
+     -
+     -
    * - `mirror-mouse-fused <https://huggingface.co/datasets/paninski-lab/mirror-mouse-fused>`_
      - 7.11 ± 0.11 px
      - 7.11 ± 0.11 px
@@ -126,10 +151,23 @@ effect on accuracy, across every dataset tested:
      - 37.41 ± 0.61 px
      - 37.41 ± 0.61 px
      - 37.44 ± 0.60 px
+   * - **Multi-view**
+     -
+     -
+     -
+   * - `mirror-mouse-separate <https://huggingface.co/datasets/paninski-lab/mirror-mouse-separate>`_ (2 views)
+     - 5.23 ± 0.65 px
+     - 4.96 ± 0.39 px
+     - 4.95 ± 0.38 px
+   * - `fly-anipose <https://huggingface.co/datasets/paninski-lab/fly-anipose>`_ (6 views)
+     - 9.34 ± 0.02 px
+     - 9.34 ± 0.02 px
+     - 9.34 ± 0.02 px
 
-Deltas are well under 0.01px in every case -- far below seed-to-seed variation (SEM). In
-short: **it is safe to run inference at reduced precision regardless of what precision the
-model was trained at.**
+Deltas are well under 0.01px in every case, single- or multi-view -- far below seed-to-seed
+variation (SEM). In short: **it is safe to run inference at reduced precision regardless of
+what precision the model was trained at, and this holds for multi-view cross-view-attention
+models as well as single-view ones.**
 
 Results: speed
 ================
@@ -137,9 +175,11 @@ Results: speed
 Reduced precision can speed up the model's forward pass, but the effect depends heavily on
 batch size and architecture. The numbers below isolate the forward pass only (synthetic
 inputs already on the GPU, no data loading) on an A100-SXM4-80GB, measured relative to a true
-FP32 baseline (TF32 disabled for both matmul and cuDNN):
+FP32 baseline (TF32 disabled for both matmul and cuDNN). These use the single-view
+architectures (ResNet50, ViT-S DINOv2) at 256x256 input (ViT-S snapped to 252x252 to divide
+evenly by its 14px patch size):
 
-.. list-table:: Forward-pass speedup vs. FP32, by batch size
+.. list-table:: Forward-pass speedup vs. FP32, by batch size (single-view, 256px input)
    :widths: 20 15 15 15
    :header-rows: 1
 
@@ -185,8 +225,42 @@ with little compute to amortize it against. The crossover point is around batch 
 by batch size 32 both architectures see a substantial speedup (roughly 3x for ResNet50, 4.4x
 for ViT-S). FP16 and BF16 perform similarly to each other on A100.
 
-**Important caveat:** these numbers measure the GPU forward pass in isolation. End-to-end
-video inference (via ``litpose predict``) did not show a measurable speedup from reduced
-precision on a T4 GPU -- video preprocessing (DALI) dominates total runtime, not the model's
-forward pass. Whether reduced precision speeds up your end-to-end workflow depends on your
-bottleneck: batch size, GPU, and video decoding overhead all matter.
+**Important caveat:** these numbers measure the GPU forward pass in isolation on a
+single-view architecture. End-to-end video inference (via ``litpose predict``) on a T4 GPU
+did not show a measurable speedup from reduced precision for single-view models either --
+video preprocessing (DALI) dominates total runtime, not the model's forward pass. Whether
+reduced precision speeds up your end-to-end workflow depends on your bottleneck: batch
+size, GPU, and video decoding overhead all matter.
+
+**Multi-view end-to-end speed.** The forward-pass benchmark above uses single-view
+architectures; multi-view models (``heatmap_multiview_transformer`` + ``vits_dinov2``)
+process every camera view simultaneously each forward pass, so we also measured end-to-end
+``litpose predict`` speed directly, 7 repeats per precision, on an A100-SXM4-80GB, 256x256
+input per view. Both datasets use the same DALI ``sequence_length`` (64), so the two rows
+below are directly comparable to each other, not just within each row:
+
+.. list-table:: End-to-end inference speed, multi-view models (A100 GPU, seq_len=64)
+   :widths: 25 20 20 20
+   :header-rows: 1
+
+   * - Dataset
+     - FP32
+     - FP16
+     - BF16
+   * - mirror-mouse-separate (2 views)
+     - 79.6s
+     - 79.8s (+0.2%)
+     - 80.0s (+0.5%)
+   * - fly-anipose (6 views)
+     - 27.2s
+     - 27.0s (-0.6%)
+     - 27.1s (-0.1%)
+
+Both datasets are flat across precisions (well under 1% spread) -- the same
+DALI/video-I/O-bound pattern seen in the single-view benchmarks. Notably, on an earlier T4
+run at a smaller, memory-constrained sequence length (16), fly-anipose showed a small but
+real slowdown at BF16 (+5.2%); that slowdown disappears here at sequence length 64 on an
+A100, consistent with our hypothesis that it was a batch-size artifact (the forward-pass
+microbenchmark above shows reduced precision is actually slower than FP32 at small batch
+sizes, crossing over to a speedup only around batch 8) rather than a fundamental property of
+multi-view models.

--- a/docs/source/user_guide_advanced/mixed_precision.rst
+++ b/docs/source/user_guide_advanced/mixed_precision.rst
@@ -225,12 +225,42 @@ with little compute to amortize it against. The crossover point is around batch 
 by batch size 32 both architectures see a substantial speedup (roughly 3x for ResNet50, 4.4x
 for ViT-S). FP16 and BF16 perform similarly to each other on A100.
 
-**Important caveat:** these numbers measure the GPU forward pass in isolation on a
-single-view architecture. End-to-end video inference (via ``litpose predict``) on a T4 GPU
-did not show a measurable speedup from reduced precision for single-view models either --
-video preprocessing (DALI) dominates total runtime, not the model's forward pass. Whether
-reduced precision speeds up your end-to-end workflow depends on your bottleneck: batch
-size, GPU, and video decoding overhead all matter.
+The same isolated-forward-pass experiment on the multi-view architecture
+(``heatmap_multiview_transformer`` + ``vits_dinov2``, 6 camera views, A100, true FP32
+baseline) shows a comparable speedup, reached at a smaller nominal batch size since each
+view multiplies the effective batch fed to the backbone:
+
+.. list-table:: Forward-pass speedup vs. FP32, by batch size (multi-view, 6 views, 256px input per view)
+   :widths: 30 15 15
+   :header-rows: 1
+
+   * - Batch size (effective ViT batch = batch x 6 views)
+     - FP16
+     - BF16
+   * - 1 (6)
+     - 1.08x
+     - 1.07x
+   * - 2 (12)
+     - 1.49x
+     - 1.63x
+   * - 4 (24)
+     - 2.89x
+     - 2.91x
+   * - 8 (48)
+     - 4.29x
+     - 4.11x
+   * - 16 (96)
+     - 4.56x
+     - 4.55x
+
+**Important caveat -- applies to both single- and multi-view:** these tables measure the
+GPU forward pass in isolation. End-to-end video inference (via ``litpose predict``) did not
+show a measurable speedup from reduced precision for either single-view models (T4 GPU) or
+multi-view models (A100 GPU, see the end-to-end table below) -- despite the multi-view
+forward pass accounting for the large majority of end-to-end wall time in a separate
+profiling pass. This is a genuine open question we haven't resolved yet: why an isolated
+forward-pass speedup this large doesn't show up end-to-end. We'll expand this section if and
+when we track down the discrepancy.
 
 **Multi-view end-to-end speed.** The forward-pass benchmark above uses single-view
 architectures; multi-view models (``heatmap_multiview_transformer`` + ``vits_dinov2``)


### PR DESCRIPTION
Follow-up to #458, adding multi-view results to the mixed precision docs page.
What changed

Merged multi-view accuracy (mirror-mouse-separate, 2 views; fly-anipose, 6 views) into the existing single-view accuracy tables, using **Single-view**/**Multi-view** group-header rows rather than a separate section.
Relabeled the forward-pass speed table as single-view (256px input), and added a new "multi-view end-to-end speed" table with view counts per dataset.
Removed the standalone "Results: multiview models" heading — its content now lives in the tables above.

Data

Accuracy: mean pixel error ± SEM across 3 seeds, same methodology as the single-view tables (heatmap_multiview_transformer + vits_dinov2, tf100). Both multi-view datasets show inference precision is free and training precision is a wash within seed noise.
Speed: re-benchmarked end-to-end litpose predict on an A100 (matching the GPU used for the single-view forward-pass numbers), same sequence_length=64 for both datasets so they're directly comparable to each other. Both are flat across FP32/FP16/BF16 (<1% spread).

Doc validated with docutils.core.publish_doctree (no errors/warnings at report_level=5). No code changes — doc-only.
