### PR TITLE
Add mixed precision training (AMP) for ~2x speedup

### DIFF
--- a/lightning_pose/train.py
+++ b/lightning_pose/train.py
@@ -419,6 +419,7 @@ def _train(cfg: DictConfig | ListConfig, status_file: Path | None = None) -> Mod
         val_check_interval=val_check_interval,
         log_every_n_steps=cfg.training.log_every_n_steps,
         callbacks=callbacks,
+	precision="16-mixed",
         logger=logger_tb,
         # To understand why we set this, see 'max_size_cycle' in UnlabeledDataModule.
         limit_train_batches=cfg.training.get("limit_train_batches") or steps_per_epoch,


### PR DESCRIPTION
This PR enables mixed precision training (AMP) by adding `precision="16-mixed"` to the `Trainer` in `lightning_pose/train.py`

Mixed precision uses FP16 for most operations which speeds up training and reduces GPU memory usage with no loss in model accuracy.

I benchmarked the performance gain using a standalone ResNet‑50 model (which is teh same backbone thats used in Lightning Pose) on a Google Colab T4 GPU since I had no access to NVIDIA GPUs. 

The test script:
- Ran 20 forward/backward passes with batch size 8 in FP32
- Ran the same passes with AMP (`torch.amp.autocast` + `GradScaler`)
- Measured wall clock time (with `torch.cuda.synchronize()`) and peak GPU memory

Results:
<img width="307" height="82" alt="image" src="https://github.com/user-attachments/assets/6cec3f29-aa79-4df5-bd42-3ab4db2184d8" />

On older GPUs or CPU, Lightning will fall back to FP32 with no errors or crashes
precision="16-mixed" is a standard Lightning flag; it works on all GPUs with compute capability ≥ 7.0 (Volta, Turing, Ampere, Ada)
