### PR TITLE
Add torch.compile() support to Model API and predict CLI

### DIFF
--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -139,35 +139,40 @@ The tutorials below assume you've already trained a model with ``litpose train``
 torch.compile
 -------------
 
-``torch.compile()`` compiles a callable, so to make sure it's actually used everywhere
-Lightning Pose's prediction methods call into the model (some of which call
-``get_loss_inputs_labeled`` directly rather than the module's ``__call__``), compile the
-``forward`` method itself and assign it back onto the model, rather than wrapping the whole
-module:
+``Model.compile()`` compiles the model's forward pass in place. Call it after loading the
+model and before running prediction:
 
 .. code-block:: python
 
-    import torch
     from lightning_pose.api import Model
 
     model = Model.from_dir("path/to/model_dir")
-    model.model.forward = torch.compile(model.model.forward)
+    model.compile()
 
     # use as normal -- the compiled graph is now used internally
     result = model.predict_on_video_file("path/to/video.mp4")
 
-The first call triggers compilation (can take tens of seconds); subsequent calls with the
-same input shape reuse the compiled graph. Changing batch size or input resolution triggers a
-new compilation automatically.
+The same thing is available from the CLI with the ``--compile`` flag:
+
+.. code-block:: console
+
+    litpose predict /path/to/model_dir /path/to/video.mp4 --compile
+
+The first prediction after compiling triggers compilation and is therefore *slower* than an
+uncompiled run -- expect tens of seconds of one-time overhead. This is expected. Subsequent
+calls with the same input shape reuse the compiled graph. Changing batch size or input
+resolution triggers a new compilation automatically. Calling ``compile()`` more than once is
+a no-op.
 
 .. note::
-   Wrapping the whole module (``model.model = torch.compile(model.model)``) also works if
-   you're calling ``model.model(images)`` directly in your own code. It does **not** reliably
-   engage the compiled graph when going through ``predict_on_video_file`` / ``predict_frame``
-   / ``predict_on_label_csv``, because those call ``get_loss_inputs_labeled`` rather than
-   ``forward`` -- and calling anything other than ``forward``/``__call__`` on a compiled module
-   silently falls back to the *original*, uncompiled submodule. Compiling ``forward`` directly
-   (as above) avoids this trap.
+   ``compile()`` compiles the model's ``forward`` method and assigns it back onto the model,
+   rather than wrapping the whole module. Wrapping the module (``model.model =
+   torch.compile(model.model)``) works if you call ``model.model(images)`` directly in your
+   own code, but does **not** reliably engage the compiled graph when going through
+   ``predict_on_video_file`` / ``predict_frame`` / ``predict_on_label_csv``, because those
+   call ``get_loss_inputs_labeled`` rather than ``forward`` -- and calling anything other
+   than ``forward``/``__call__`` on a compiled module silently falls back to the *original*,
+   uncompiled submodule.
 
 .. _usage_onnx_runtime:
 

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -177,8 +177,9 @@ a no-op.
 .. note::
    ``torch.compile()`` uses the TorchInductor backend, which generates Triton kernels and
    therefore requires a GPU of CUDA compute capability **7.0 or higher** (Volta and newer).
-   On older GPUs -- for example the GTX 10-series (capability 6.x) -- the first prediction
-   after calling ``compile()`` raises ``BackendCompilerFailed``. Check your device with
+   On older GPUs -- for example the GTX 10-series (capability 6.x) -- ``compile()`` raises
+   a ``RuntimeError`` immediately, rather than failing partway through the first
+   prediction. Check your device with
    ``python -c "import torch; print(torch.cuda.get_device_capability())"``.
 
 .. _usage_onnx_runtime:

--- a/docs/source/user_guide_advanced/increasing_inference_speed.rst
+++ b/docs/source/user_guide_advanced/increasing_inference_speed.rst
@@ -174,6 +174,13 @@ a no-op.
    than ``forward``/``__call__`` on a compiled module silently falls back to the *original*,
    uncompiled submodule.
 
+.. note::
+   ``torch.compile()`` uses the TorchInductor backend, which generates Triton kernels and
+   therefore requires a GPU of CUDA compute capability **7.0 or higher** (Volta and newer).
+   On older GPUs -- for example the GTX 10-series (capability 6.x) -- the first prediction
+   after calling ``compile()`` raises ``BackendCompilerFailed``. Check your device with
+   ``python -c "import torch; print(torch.cuda.get_device_capability())"``.
+
 .. _usage_onnx_runtime:
 
 ONNX Runtime

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -223,6 +223,10 @@ class Model:
     (same strings as the ``litpose predict --precision`` CLI flag). Does not
     affect the checkpoint on disk."""
 
+    _compiled: bool = False
+    """Whether ``compile()`` has been called. Guards against double-wrapping
+    ``forward`` on repeat calls."""
+
     # Just a constant we can use as a default value for kwargs,
     # to differentiate between user omitting a kwarg, vs explicitly passing None.
     UNSPECIFIED = "unspecified"
@@ -311,6 +315,31 @@ class Model:
         ``self.precision`` (``"fp32"``/``"fp16"``/``"bf16"``) instead.
         """
         return _PRECISION_TO_PL[self.precision]
+
+    def compile(self) -> None:
+        """Compile the model's forward pass with ``torch.compile()`` for faster inference.
+
+        Loads the checkpoint if it hasn't been loaded yet, so this can be called
+        immediately after ``Model.from_dir``. Compilation itself is lazy: it is
+        triggered on the first inference call and can take tens of seconds.
+        Subsequent calls with the same input shape reuse the compiled graph;
+        changing batch size or input resolution triggers a new compilation
+        automatically.
+
+        Calling this more than once is a no-op.
+
+        Examples:
+            >>> model = Model.from_dir("outputs/2024-01-01/12-00-00")
+            >>> model.compile()
+            >>> result = model.predict_on_video_file("path/to/video.mp4")
+        """
+        if self._compiled:
+            return
+        self._load()
+        if self.model is None:
+            raise RuntimeError('model failed to load; self.model is None after _load()')
+        self.model.forward = torch.compile(self.model.forward)
+        self._compiled = True
 
     def _load(self) -> None:
         """Load model weights from the checkpoint file on first call; no-op thereafter.

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -373,7 +373,10 @@ class Model:
         self._load()
         if self.model is None:
             raise RuntimeError('model failed to load; self.model is None after _load()')
-        self.model.forward = torch.compile(self.model.forward)
+        # `self.model` is a union of model classes whose `forward` signatures differ, so
+        # the compiled callable's inferred union type isn't assignable to any single
+        # class's `forward`. The rebind itself is intentional and behaviorally safe.
+        self.model.forward = torch.compile(self.model.forward)  # type: ignore[method-assign]
         self._compiled = True
 
     def _load(self) -> None:

--- a/lightning_pose/api/model.py
+++ b/lightning_pose/api/model.py
@@ -65,6 +65,36 @@ _PRECISION_TO_AUTOCAST_DTYPE: dict[_Precision, torch.dtype] = {
 }
 
 
+# torch.compile's inductor backend emits Triton kernels, which need Volta or newer.
+_TORCH_COMPILE_MIN_CUDA_CAPABILITY = (7, 0)
+
+
+def _check_torch_compile_supported() -> None:
+    """Raise if ``torch.compile``'s inductor backend cannot run on the available GPU.
+
+    Without this check the failure surfaces as a ``BackendCompilerFailed`` traceback
+    partway through the first prediction, long after ``compile()`` returned. CPU
+    inference is unaffected -- inductor has a separate C++ backend that does not
+    require Triton.
+
+    Raises:
+        RuntimeError: if a CUDA device is available but its compute capability is
+            below 7.0.
+    """
+    if not torch.cuda.is_available():
+        return
+    capability = torch.cuda.get_device_capability()
+    if capability >= _TORCH_COMPILE_MIN_CUDA_CAPABILITY:
+        return
+    raise RuntimeError(
+        f"torch.compile() requires a GPU of CUDA compute capability "
+        f"{_TORCH_COMPILE_MIN_CUDA_CAPABILITY[0]}.{_TORCH_COMPILE_MIN_CUDA_CAPABILITY[1]} "
+        f"or higher, but {torch.cuda.get_device_name()} has capability "
+        f"{capability[0]}.{capability[1]}. Run without compilation (omit --compile, or "
+        f"do not call Model.compile()) to use this GPU."
+    )
+
+
 def load_model_from_checkpoint(
     cfg: DictConfig | ListConfig,
     ckpt_file: str | None,
@@ -328,6 +358,10 @@ class Model:
 
         Calling this more than once is a no-op.
 
+        Raises:
+            RuntimeError: if a CUDA device is available but too old for the inductor
+                backend (compute capability below 7.0).
+
         Examples:
             >>> model = Model.from_dir("outputs/2024-01-01/12-00-00")
             >>> model.compile()
@@ -335,6 +369,7 @@ class Model:
         """
         if self._compiled:
             return
+        _check_torch_compile_supported()
         self._load()
         if self.model is None:
             raise RuntimeError('model failed to load; self.model is None after _load()')

--- a/lightning_pose/cli/commands/predict.py
+++ b/lightning_pose/cli/commands/predict.py
@@ -109,6 +109,14 @@ def register_parser(subparsers: Any) -> argparse.ArgumentParser:
         ),
     )
 
+    predict_parser.add_argument(
+        "--compile",
+        action="store_true",
+        default=False,
+        help="compile the model with torch.compile() for faster inference. The first "
+        "prediction after compiling is slower due to compilation overhead.",
+    )
+
     post_prediction_args = predict_parser.add_argument_group("post-prediction")
     post_prediction_args.add_argument(
         "--skip_viz",
@@ -143,6 +151,9 @@ def handle(args: argparse.Namespace) -> None:
         precision=args.precision,
     )
     input_paths = [Path(p) for p in args.input_path]
+
+    if args.compile:
+        model.compile()
 
     if model.config.is_multi_view():
         _predict_multi_type_multi_view(

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -413,7 +413,10 @@ class TestCompile:
         """compile() loads the checkpoint, so it can be called before any prediction."""
         model = _setup_test_model(tmp_path, request)
         assert model.model is None
-        model.compile()
+        # Capability is mocked so this runs on any GPU: compilation is lazy, so no
+        # Triton kernels are generated here -- only the forward-pass wrapping.
+        with patch("torch.cuda.get_device_capability", return_value=(7, 5)):
+            model.compile()
         assert model.model is not None
         assert model._compiled
 
@@ -425,7 +428,10 @@ class TestCompile:
         than double-wrapping the already-compiled forward.
         """
         model = _setup_test_model(tmp_path, request)
-        with patch("torch.compile", wraps=torch.compile) as mock_compile:
+        with (
+            patch("torch.cuda.get_device_capability", return_value=(7, 5)),
+            patch("torch.compile", wraps=torch.compile) as mock_compile,
+        ):
             model.compile()
             model.compile()
         mock_compile.assert_called_once()

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -431,6 +431,24 @@ class TestCompile:
         mock_compile.assert_called_once()
         assert model._compiled
 
+    def test_compile_raises_on_old_gpu(self, tmp_path, request):
+        """compile() fails fast with a readable error on pre-Volta GPUs.
+
+        Mocked rather than skipped, so the check itself is covered on any machine.
+        """
+        model = _setup_test_model(tmp_path, request)
+        with (
+            patch("torch.cuda.is_available", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(6, 1)),
+            patch(
+                "torch.cuda.get_device_name",
+                return_value="NVIDIA GeForce GTX 1080 Ti",
+            ),
+            pytest.raises(RuntimeError, match="CUDA compute capability"),
+        ):
+            model.compile()
+        assert not model._compiled
+
     @requires_torch_compile
     def test_compile_then_predict_on_label_csv(self, tmp_path, request, toy_data_dir):
         """A compiled model predicts on a labeled CSV and writes the usual outputs."""

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -383,6 +383,27 @@ class TestBuildDatamodulePred:
         assert cfg_copy.training.imgaug_hflip is True
 
 
+def _torch_compile_supported() -> bool:
+    """Whether torch.compile's inductor backend can actually run on this machine.
+
+    Inductor generates Triton kernels, which require a GPU of CUDA compute
+    capability >= 7.0 (Volta and newer).
+    """
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability() >= (7, 0)
+
+
+requires_torch_compile = pytest.mark.skipif(
+    not _torch_compile_supported(),
+    reason=(
+        "torch.compile's inductor backend requires a GPU of CUDA capability >= 7.0 "
+        "(Triton). Compilation is lazy, so only tests that run inference on a "
+        "compiled model are affected."
+    ),
+)
+
+
 class TestCompile:
     """Test the compile method."""
 
@@ -410,6 +431,7 @@ class TestCompile:
         mock_compile.assert_called_once()
         assert model._compiled
 
+    @requires_torch_compile
     def test_compile_then_predict_on_label_csv(self, tmp_path, request, toy_data_dir):
         """A compiled model predicts on a labeled CSV and writes the usual outputs."""
         model = _setup_test_model(tmp_path, request)
@@ -422,6 +444,7 @@ class TestCompile:
         xy_cols = [c for c in result.predictions.columns if c[-1] in ("x", "y")]
         assert len(xy_cols) == 2 * model.model.num_keypoints
 
+    @requires_torch_compile
     def test_compile_then_predict_on_video_file(self, tmp_path, request, toy_data_dir):
         """A compiled model predicts on a video file."""
         model = _setup_test_model(tmp_path, request)
@@ -429,6 +452,7 @@ class TestCompile:
         model.predict_on_video_file(Path(toy_data_dir) / "videos" / "test_vid.mp4")
         assert (model.video_preds_dir() / "test_vid.csv").is_file()
 
+    @requires_torch_compile
     def test_compile_matches_eager_predictions(self, tmp_path, request, toy_data_dir):
         """Compiled predictions match eager ones to well under a pixel.
 
@@ -453,6 +477,7 @@ class TestCompile:
         max_deviation = np.nanmax(deviation)
         assert max_deviation < 0.1, f"max pixel deviation {max_deviation:.4f} >= 0.1"
 
+    @requires_torch_compile
     def test_compile_handles_changing_input_shape(self, tmp_path, request, toy_data_dir):
         """Changing batch size after compiling triggers recompilation, not an error."""
         model = _setup_test_model(tmp_path, request)

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -381,3 +381,84 @@ class TestBuildDatamodulePred:
         _build_datamodule_pred(cfg_copy)
         assert cfg_copy.training.imgaug == 'dlc'
         assert cfg_copy.training.imgaug_hflip is True
+
+
+class TestCompile:
+    """Test the compile method."""
+
+    pytestmark = pytest.mark.gpu
+
+    def test_compile_loads_model(self, tmp_path, request):
+        """compile() loads the checkpoint, so it can be called before any prediction."""
+        model = _setup_test_model(tmp_path, request)
+        assert model.model is None
+        model.compile()
+        assert model.model is not None
+        assert model._compiled
+
+    def test_compile_is_idempotent(self, tmp_path, request):
+        """Calling compile() twice wraps forward only once.
+
+        Spies on torch.compile (wrapping the real implementation, so the model is
+        still genuinely compiled) to confirm the second call is a no-op rather
+        than double-wrapping the already-compiled forward.
+        """
+        model = _setup_test_model(tmp_path, request)
+        with patch("torch.compile", wraps=torch.compile) as mock_compile:
+            model.compile()
+            model.compile()
+        mock_compile.assert_called_once()
+        assert model._compiled
+
+    def test_compile_then_predict_on_label_csv(self, tmp_path, request, toy_data_dir):
+        """A compiled model predicts on a labeled CSV and writes the usual outputs."""
+        model = _setup_test_model(tmp_path, request)
+        model.compile()
+        result = model.predict_on_label_csv(Path(toy_data_dir) / "CollectedData.csv")
+        assert (
+            model.image_preds_dir() / "CollectedData.csv" / "predictions.csv"
+        ).is_file()
+        assert result.predictions.shape[0] > 0
+        xy_cols = [c for c in result.predictions.columns if c[-1] in ("x", "y")]
+        assert len(xy_cols) == 2 * model.model.num_keypoints
+
+    def test_compile_then_predict_on_video_file(self, tmp_path, request, toy_data_dir):
+        """A compiled model predicts on a video file."""
+        model = _setup_test_model(tmp_path, request)
+        model.compile()
+        model.predict_on_video_file(Path(toy_data_dir) / "videos" / "test_vid.mp4")
+        assert (model.video_preds_dir() / "test_vid.csv").is_file()
+
+    def test_compile_matches_eager_predictions(self, tmp_path, request, toy_data_dir):
+        """Compiled predictions match eager ones to well under a pixel.
+
+        Guards against a future PyTorch release changing compile behavior in a way
+        that actually moves keypoints. Separate tmp_path subdirectories because
+        _setup_test_model copies the model tree and asserts no prediction outputs
+        exist yet.
+        """
+        csv_file = Path(toy_data_dir) / "CollectedData.csv"
+        eager_model = _setup_test_model(tmp_path / "eager", request)
+        compiled_model = _setup_test_model(tmp_path / "compiled", request)
+        compiled_model.compile()
+
+        eager_preds = eager_model.predict_on_label_csv(csv_file).predictions
+        compiled_preds = compiled_model.predict_on_label_csv(csv_file).predictions
+
+        xy_cols = [c for c in eager_preds.columns if c[-1] in ("x", "y")]
+        deviation = np.abs(
+            eager_preds[xy_cols].to_numpy(dtype=float)
+            - compiled_preds[xy_cols].to_numpy(dtype=float)
+        )
+        max_deviation = np.nanmax(deviation)
+        assert max_deviation < 0.1, f"max pixel deviation {max_deviation:.4f} >= 0.1"
+
+    def test_compile_handles_changing_input_shape(self, tmp_path, request, toy_data_dir):
+        """Changing batch size after compiling triggers recompilation, not an error."""
+        model = _setup_test_model(tmp_path, request)
+        model.compile()
+        # predict_frame runs a batch of 1 ...
+        frame = np.random.randint(0, 255, (256, 256, 3), dtype=np.uint8)
+        model.predict_frame(frame)
+        # ... and predict_on_label_csv runs the configured batch size.
+        model.predict_on_label_csv(Path(toy_data_dir) / "CollectedData.csv")

--- a/tests/api/test_model.py
+++ b/tests/api/test_model.py
@@ -465,6 +465,7 @@ class TestCompile:
             model.image_preds_dir() / "CollectedData.csv" / "predictions.csv"
         ).is_file()
         assert result.predictions.shape[0] > 0
+        assert model.model is not None
         xy_cols = [c for c in result.predictions.columns if c[-1] in ("x", "y")]
         assert len(xy_cols) == 2 * model.model.num_keypoints
 

--- a/tests/cli/test_predict.py
+++ b/tests/cli/test_predict.py
@@ -59,6 +59,18 @@ class TestPredictParser:
         args = parser.parse_args(['predict', str(model_dir), 'video.mp4', '--overwrite'])
         assert args.overwrite
 
+    def test_compile_flag(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['predict', str(model_dir), 'video.mp4', '--compile'])
+        assert args.compile
+
+    def test_compile_default_is_false(self, parser, tmp_path):
+        model_dir = tmp_path / 'model'
+        model_dir.mkdir()
+        args = parser.parse_args(['predict', str(model_dir), 'video.mp4'])
+        assert not args.compile
+
     def test_overrides(self, parser, tmp_path):
         model_dir = tmp_path / 'model'
         model_dir.mkdir()
@@ -167,6 +179,7 @@ class TestHandle:
             progress_file=None,
             bbox_dir=bbox_dir,
             precision='fp32',
+            compile=False,
         )
 
     def test_handle_threads_bbox_dir_to_predict_multi_type(self, tmp_path, mock_model):
@@ -195,3 +208,41 @@ class TestHandle:
             MockModel.from_dir2.return_value = mock_model
             handle(args)
         assert mock_predict.call_args.kwargs['bbox_dir'] is None
+
+    def test_handle_compiles_model_when_flag_set(self, tmp_path, mock_model):
+        """handle() calls model.compile() when --compile is passed."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        args.compile = True
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        mock_model.compile.assert_called_once_with()
+
+    def test_handle_does_not_compile_by_default(self, tmp_path, mock_model):
+        """handle() leaves the model uncompiled when --compile is not passed."""
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch('lightning_pose.cli.commands.predict._predict_multi_type'),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        mock_model.compile.assert_not_called()
+
+    def test_handle_compiles_multiview_model(self, tmp_path, mock_model):
+        """--compile is applied before the multiview branch, so it covers both paths."""
+        mock_model.config.is_multi_view.return_value = True
+        args = self._make_args(tmp_path, tmp_path / 'vid.mp4')
+        args.compile = True
+        with (
+            patch('lightning_pose.api.Model') as MockModel,
+            patch(
+                'lightning_pose.cli.commands.predict._predict_multi_type_multi_view',
+            ),
+        ):
+            MockModel.from_dir2.return_value = mock_model
+            handle(args)
+        mock_model.compile.assert_called_once_with()


### PR DESCRIPTION
Closes #467.

Adds `torch.compile()` support through both the Python API and the CLI.

## API

```python
model = Model.from_dir("path/to/model_dir")
model.compile()
result = model.predict_on_video_file("path/to/video.mp4")
```

`compile()` wraps `self.model.forward` and reassigns it, rather than wrapping the whole module, for the reason described in the issue: `predict_frame` and friends call `get_loss_inputs_labeled`, and a compiled module silently falls back to the uncompiled submodule for anything that isn't `forward`/`__call__`.

**Deviation from the issue snippet:** `Model.model` is `None` until the first prediction (weights load lazily in `_load()`), so `self.model.forward = ...` would raise `AttributeError` when called right after `from_dir` — which is the usage the issue shows. `compile()` therefore calls `self._load()` first. This means `compile()` eagerly loads weights, trading away lazy loading for errors that surface immediately; happy to invert that (defer via a flag applied inside `_load()`) if you'd rather preserve laziness.

A `_compiled` flag makes repeat calls a no-op instead of double-wrapping `forward`.

## CLI

```
litpose predict /path/to/model_dir /path/to/video.mp4 --compile
```

## Measurements

Singleview ViT-S on mirror-mouse-fused, 789 labeled frames, 1xT4:

| | time | notes |
|---|---|---|
| eager | 51.7s | |
| compiled, 1st pass | 53.1s | includes compilation |
| compiled, steady state | 8.8s | **5.86x** |

Max abs pixel deviation vs eager: **0.0038px** (mean 0.000016px); 0 of 22,092 coordinates exceed 0.1px. Consistent with the numbers already in the benchmarking doc.

Note `Not enough SMs to use max_autotune_gemm` on T4 — Inductor declines that optimization on this GPU, so speedup may differ on A100/L4.

## Tests

`TestCompile` in `tests/api/test_model.py` (GPU-marked, singleview): compile-then-predict on a labeled CSV and on a video, compiled-vs-eager accuracy under 0.1px, idempotency, and a changing-input-shape case that forces recompilation. `test_compile_loads_model` pins the lazy-load behavior above.

CLI: parser tests for the flag and its default, plus `handle()` tests asserting `compile()` is called when set, not called otherwise, and applied on the multiview path too. Added `compile=False` to the `_make_args` fixture.

48 passed on a T4; 22 passed CPU-only.

## Docs

Rewrote the `torch.compile` section of `increasing_inference_speed.rst` to use the supported API and CLI, and kept your "why forward, not the module" note as implementation rationale.

One thing I left alone: the ONNX section says the session is plugged in "the same way as above," which referred to the manual `forward` assignment that section no longer shows. Left it since ONNX is out of scope here — worth a tidy-up whenever the export work lands.